### PR TITLE
re-implement phantom selection as it's own submodule.

### DIFF
--- a/tapdance/conjure_test.go
+++ b/tapdance/conjure_test.go
@@ -2,93 +2,11 @@ package tapdance
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"encoding/hex"
 	"testing"
 
 	pb "github.com/refraction-networking/gotapdance/protobuf"
 )
-
-func TestSelectIpv4(t *testing.T) {
-
-	_ddIPSelector, err := newDDIpSelector([]string{"192.122.190.0/24", "2001:48a8:687f:1::/64"}, false)
-	if err != nil {
-		t.Fatal("Failed IP selector initialization ", err)
-	}
-
-	for _, _net := range _ddIPSelector.nets {
-		if _net.IP.To4() == nil {
-			t.Fatal("Encountered Non IPv4 Network block")
-		}
-	}
-
-	seed := make([]byte, 16)
-	_, err = rand.Read(seed)
-	if err != nil {
-		t.Fatalf("Crypto/Rand error -- %s\n", err)
-	}
-
-	darDecoyIPAddr, err := _ddIPSelector.selectIpAddr(seed)
-	if err != nil {
-		t.Fatalf("Error selecting decoy address -- %s\n", err)
-	}
-	if darDecoyIPAddr.To4() == nil {
-		t.Fatal("No IPv4 address Selected")
-	}
-
-	seed = []byte{
-		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
-		0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF,
-	}
-
-	phantomIPAddr4, phantomIPAddr6, err := SelectPhantom(seed, v4)
-	if err != nil || phantomIPAddr4 == nil {
-		t.Fatalf("Failed to select IP address (support: v4): %v", err)
-	} else if phantomIPAddr6 != nil {
-		t.Fatalf("Chose v6 address when v4 specified")
-	} else if phantomIPAddr4.String() != "141.219.19.101" {
-		t.Fatalf("Incorrect Address chosen: %v", phantomIPAddr4.String())
-	}
-}
-
-func TestSelectIpv6(t *testing.T) {
-
-	_ddIPSelector, err := newDDIpSelector([]string{"192.122.190.0/24", "2001:48a8:687f:1::/64"}, true)
-	if err != nil {
-		t.Fatal("Failed IP selector initialization ", err)
-	}
-
-	for _, _net := range _ddIPSelector.nets {
-		if _net.IP.To16() == nil && _net.IP.To4() == nil {
-			t.Fatal("Encountered Unknown Network block")
-		}
-	}
-
-	seed := make([]byte, 16)
-	_, err = rand.Read(seed)
-	if err != nil {
-		t.Fatalf("Crypto/Rand error -- %s\n", err)
-	}
-
-	_, err = _ddIPSelector.selectIpAddr(seed)
-	if err != nil {
-		t.Fatalf("Error selecting decoy address -- %s\n", err)
-	}
-
-	seed = []byte{
-		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
-		0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF,
-	}
-
-	phantomIPAddr4, phantomIPAddr6, err := SelectPhantom(seed, v6)
-	if err != nil || phantomIPAddr6 == nil || phantomIPAddr4 != nil {
-		t.Fatalf("Failed to select IP address (support: v6): %v", err)
-	} else if phantomIPAddr4 != nil {
-		t.Fatalf("Chose v4 address when v6 specified")
-	} else if phantomIPAddr6.String() != "2001:48a8:687f:1:305:709:b11:2024" {
-		t.Fatalf("Incorrect Address chosen: %s", phantomIPAddr6.String())
-	}
-}
 
 func TestSelectBoth(t *testing.T) {
 	seed := []byte{
@@ -103,9 +21,9 @@ func TestSelectBoth(t *testing.T) {
 		t.Fatalf("Failed to select IPv4 address (support: both): %v", err)
 	} else if phantomIPAddr6 == nil {
 		t.Fatalf("Failed to select IPv6 address (support: both): %v", err)
-	} else if phantomIPAddr6.String() != "2001:48a8:687f:1:305:709:b11:2024" {
+	} else if phantomIPAddr6.String() != "2001:48a8:687f:1:41d3:ff12:45b:73c8" {
 		t.Fatalf("Incorrect Address chosen: %s", phantomIPAddr6.String())
-	} else if phantomIPAddr4.String() != "141.219.19.101" {
+	} else if phantomIPAddr4.String() != "192.122.190.194" {
 		t.Fatalf("Incorrect Address chosen: %v", phantomIPAddr4.String())
 	}
 }

--- a/tapdance/phantoms/phantoms.go
+++ b/tapdance/phantoms/phantoms.go
@@ -105,6 +105,11 @@ func parseSubnets(phantomSubnets []string) ([]*net.IPNet, error) {
 	// return nil, fmt.Errorf("parseSubnets not implemented yet")
 }
 
+// SelectAddrFromSubnet - given a seed and a CIDR block choose an address.
+// 		This is done by generating a seeded random bytes up to teh length of the
+//		full address then using the net mask to zero out any bytes that are
+//		already specified by the CIDR block. Tde masked random value is then
+//		added to the cidr block base giving the final randomly selected address.
 func SelectAddrFromSubnet(seed []byte, net1 *net.IPNet) (net.IP, error) {
 	bits, addrLen := net1.Mask.Size()
 
@@ -182,7 +187,7 @@ func selectIPAddr(seed []byte, subnets []*net.IPNet) (*net.IP, error) {
 
 	id := &big.Int{}
 	id.SetBytes(seed)
-	if id.Cmp(addresses_total) >= 0 {
+	if id.Cmp(addresses_total) > 0 {
 		id.Mod(id, addresses_total)
 	}
 
@@ -194,21 +199,6 @@ func selectIPAddr(seed []byte, subnets []*net.IPNet) (*net.IP, error) {
 			if err != nil {
 				return nil, fmt.Errorf("Failed to chose IP address: %v", err)
 			}
-			// if ipv4net := _idNet.net.IP.To4(); ipv4net != nil {
-			// 	ipBigInt := &big.Int{}
-			// 	ipBigInt.SetBytes(ipv4net)
-			// 	ipNetDiff := _idNet.max.Sub(id, &_idNet.min)
-			// 	ipBigInt.Add(ipBigInt, ipNetDiff)
-			// 	result = net.IP(ipBigInt.Bytes()).To4() // implicit check that it fits
-			// } else if ipv6net := _idNet.net.IP.To16(); ipv6net != nil {
-			// 	ipBigInt := &big.Int{}
-			// 	ipBigInt.SetBytes(ipv6net)
-			// 	ipNetDiff := _idNet.max.Sub(id, &_idNet.min)
-			// 	ipBigInt.Add(ipBigInt, ipNetDiff)
-			// 	result = net.IP(ipBigInt.Bytes()).To16()
-			// } else {
-			// 	return nil, fmt.Errorf("failed to parse %v", _idNet.net.IP)
-			// }
 		}
 	}
 	if result == nil {

--- a/tapdance/phantoms/phantoms.go
+++ b/tapdance/phantoms/phantoms.go
@@ -1,0 +1,246 @@
+package phantoms
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log"
+	"math/big"
+	"math/rand"
+	"net"
+
+	wr "github.com/mroth/weightedrand"
+)
+
+type ConjurePhantomSubnet struct {
+	Weight  float32
+	Subnets []string
+}
+
+type SubnetConfig struct {
+	WeightedSubnets []ConjurePhantomSubnet
+}
+
+// getSubnets - return EITHER all subnet strings as one composite array if we are
+//		selecting unweighted, or return the array associated with the (seed) selected
+//		array of subnet strings based on the associated weights
+func (sc *SubnetConfig) getSubnets(seed []byte, weighted bool) []string {
+
+	var out []string = []string{}
+
+	if weighted {
+		// seed random with hkdf derived seed provided by client
+		seedInt, err := binary.ReadVarint(bytes.NewBuffer(seed))
+		if err != nil {
+			return nil
+		}
+		rand.Seed(seedInt)
+
+		choices := make([]wr.Choice, 0, len(sc.WeightedSubnets))
+		for _, cjSubnet := range sc.WeightedSubnets {
+			choices = append(choices, wr.Choice{Item: cjSubnet.Subnets, Weight: uint(cjSubnet.Weight)})
+		}
+		c := wr.NewChooser(choices...)
+		out = c.Pick().([]string)
+	} else {
+
+		// Use unweighted config for subnets, concat all into one array and return.
+		for _, cjSubnet := range sc.WeightedSubnets {
+			for _, subnet := range cjSubnet.Subnets {
+				out = append(out, subnet)
+			}
+		}
+	}
+
+	return out
+}
+
+// SubnetFilter - Filter IP subnets based on whatever to prevent specific subnets from
+//		inclusion in choice. See v4Only and v6Only for reference.
+type SubnetFilter func([]*net.IPNet) ([]*net.IPNet, error)
+
+func V4Only(obj []*net.IPNet) ([]*net.IPNet, error) {
+	var out []*net.IPNet = []*net.IPNet{}
+
+	for _, _net := range obj {
+		if ipv4net := _net.IP.To4(); ipv4net != nil {
+			out = append(out, _net)
+		}
+	}
+	return out, nil
+}
+
+func V6Only(obj []*net.IPNet) ([]*net.IPNet, error) {
+	var out []*net.IPNet = []*net.IPNet{}
+
+	for _, _net := range obj {
+		if ipv6net := _net.IP.To16(); ipv6net != nil {
+			out = append(out, _net)
+		}
+	}
+	return out, nil
+}
+
+func parseSubnets(phantomSubnets []string) ([]*net.IPNet, error) {
+	var subnets []*net.IPNet = []*net.IPNet{}
+
+	if len(phantomSubnets) == 0 {
+		return nil, fmt.Errorf("parseSubnets - no subnets provided")
+	}
+
+	for _, strNet := range phantomSubnets {
+		_, parsedNet, err := net.ParseCIDR(strNet)
+		if err != nil {
+			return nil, err
+		}
+		if parsedNet == nil {
+			return nil, fmt.Errorf("failed to parse %v as subnet", parsedNet)
+		}
+
+		subnets = append(subnets, parsedNet)
+	}
+
+	return subnets, nil
+	// return nil, fmt.Errorf("parseSubnets not implemented yet")
+}
+
+func SelectAddrFromSubnet(seed []byte, net1 *net.IPNet) (net.IP, error) {
+	bits, addrLen := net1.Mask.Size()
+
+	ipBigInt := &big.Int{}
+	if v4net := net1.IP.To4(); v4net != nil {
+		ipBigInt.SetBytes(net1.IP.To4())
+	} else if v6net := net1.IP.To16(); v6net != nil {
+		ipBigInt.SetBytes(net1.IP.To16())
+	}
+
+	seedInt, err := binary.ReadVarint(bytes.NewBuffer(seed))
+	if err != nil {
+		return nil, err
+	}
+
+	rand.Seed(seedInt)
+	randBytes := make([]byte, addrLen/8)
+	_, err = rand.Read(randBytes)
+	if err != nil {
+		return nil, err
+	}
+	randBigInt := &big.Int{}
+	randBigInt.SetBytes(randBytes)
+
+	mask := make([]byte, addrLen/8)
+	for i := 0; i < addrLen/8; i++ {
+		mask[i] = 0xff
+	}
+	maskBigInt := &big.Int{}
+	maskBigInt.SetBytes(mask)
+	maskBigInt.Rsh(maskBigInt, uint(bits))
+
+	randBigInt.And(randBigInt, maskBigInt)
+	ipBigInt.Add(ipBigInt, randBigInt)
+
+	return net.IP(ipBigInt.Bytes()), nil
+}
+
+func selectIPAddr(seed []byte, subnets []*net.IPNet) (*net.IP, error) {
+
+	addresses_total := big.NewInt(0)
+
+	type idNet struct {
+		min, max big.Int
+		net      *net.IPNet
+	}
+	var idNets []idNet
+
+	for _, _net := range subnets {
+		netMaskOnes, _ := _net.Mask.Size()
+		if ipv4net := _net.IP.To4(); ipv4net != nil {
+			_idNet := idNet{}
+			_idNet.min.Set(addresses_total)
+			addresses_total.Add(addresses_total, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(32-netMaskOnes)), nil))
+			addresses_total.Sub(addresses_total, big.NewInt(1))
+			_idNet.max.Set(addresses_total)
+			_idNet.net = _net
+			idNets = append(idNets, _idNet)
+		} else if ipv6net := _net.IP.To16(); ipv6net != nil {
+			_idNet := idNet{}
+			_idNet.min.Set(addresses_total)
+			addresses_total.Add(addresses_total, big.NewInt(2).Exp(big.NewInt(2), big.NewInt(int64(128-netMaskOnes)), nil))
+			addresses_total.Sub(addresses_total, big.NewInt(1))
+			_idNet.max.Set(addresses_total)
+			_idNet.net = _net
+			idNets = append(idNets, _idNet)
+		} else {
+			return nil, fmt.Errorf("failed to parse %v", _net)
+		}
+	}
+
+	if addresses_total.Cmp(big.NewInt(0)) <= 0 {
+		return nil, fmt.Errorf("No valid addresses specified")
+	}
+
+	id := &big.Int{}
+	id.SetBytes(seed)
+	if id.Cmp(addresses_total) >= 0 {
+		id.Mod(id, addresses_total)
+	}
+
+	var result net.IP
+	var err error
+	for _, _idNet := range idNets {
+		if _idNet.max.Cmp(id) >= 0 && _idNet.min.Cmp(id) == -1 {
+			result, err = SelectAddrFromSubnet(seed, _idNet.net)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to chose IP address: %v", err)
+			}
+			// if ipv4net := _idNet.net.IP.To4(); ipv4net != nil {
+			// 	ipBigInt := &big.Int{}
+			// 	ipBigInt.SetBytes(ipv4net)
+			// 	ipNetDiff := _idNet.max.Sub(id, &_idNet.min)
+			// 	ipBigInt.Add(ipBigInt, ipNetDiff)
+			// 	result = net.IP(ipBigInt.Bytes()).To4() // implicit check that it fits
+			// } else if ipv6net := _idNet.net.IP.To16(); ipv6net != nil {
+			// 	ipBigInt := &big.Int{}
+			// 	ipBigInt.SetBytes(ipv6net)
+			// 	ipNetDiff := _idNet.max.Sub(id, &_idNet.min)
+			// 	ipBigInt.Add(ipBigInt, ipNetDiff)
+			// 	result = net.IP(ipBigInt.Bytes()).To16()
+			// } else {
+			// 	return nil, fmt.Errorf("failed to parse %v", _idNet.net.IP)
+			// }
+		}
+	}
+	if result == nil {
+		return nil, errors.New("let's rewrite the phantom address selector")
+	}
+	return &result, nil
+}
+
+// SelectPhantom - select one phantom IP address based on shared secret
+func SelectPhantom(seed []byte, subnets SubnetConfig, transform SubnetFilter, weighted bool) (*net.IP, error) {
+
+	s, err := parseSubnets(subnets.getSubnets(seed, weighted))
+	if err != nil {
+		log.Fatalf("Failed to parse subnets: %v", err)
+	}
+
+	if transform != nil {
+		s, err = transform(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return selectIPAddr(seed, s)
+}
+
+// SelectPhantomUnweighted - select one phantom IP address based on shared secret
+func SelectPhantomUnweighted(seed []byte, subnets SubnetConfig, transform SubnetFilter) (*net.IP, error) {
+	return SelectPhantom(seed, subnets, transform, false)
+}
+
+// SelectPhantomWeighted - select one phantom IP address based on shared secret
+func SelectPhantomWeighted(seed []byte, subnets SubnetConfig, transform SubnetFilter) (*net.IP, error) {
+	return SelectPhantom(seed, subnets, transform, true)
+}

--- a/tapdance/phantoms/phantoms_test.go
+++ b/tapdance/phantoms/phantoms_test.go
@@ -46,8 +46,8 @@ func TestSelectWeightedMany(t *testing.T) {
 
 	var ps = SubnetConfig{
 		WeightedSubnets: []ConjurePhantomSubnet{
-			{Weight: 9, Subnets: []string{"192.122.190.0/24"}}, //curveball, ?
-			{Weight: 1, Subnets: []string{"141.219.0.0/16"}},   // windy-egret
+			{Weight: 9, Subnets: []string{"192.122.190.0/24"}},
+			{Weight: 1, Subnets: []string{"141.219.0.0/16"}},
 		},
 	}
 
@@ -82,8 +82,8 @@ func TestWeightedSelection(t *testing.T) {
 
 	var ps = SubnetConfig{
 		WeightedSubnets: []ConjurePhantomSubnet{
-			{Weight: 9, Subnets: []string{"1"}}, //curveball, ?
-			{Weight: 1, Subnets: []string{"2"}}, // windy-egret
+			{Weight: 9, Subnets: []string{"1"}},
+			{Weight: 1, Subnets: []string{"2"}},
 		},
 	}
 
@@ -116,7 +116,7 @@ var phantomSubnets = SubnetConfig{
 }
 
 func TestSelectFilter(t *testing.T) {
-	seed, err := hex.DecodeString("5a87133b68da3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f")
+	seed, err := hex.DecodeString("5a87133b68ea3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f")
 	if err != nil {
 		t.Fatalf("Issue decoding seedStr")
 	}

--- a/tapdance/phantoms/phantoms_test.go
+++ b/tapdance/phantoms/phantoms_test.go
@@ -1,0 +1,141 @@
+package phantoms
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"net"
+	"testing"
+)
+
+func TestIPSelectionAlt(t *testing.T) {
+
+	seed, err := hex.DecodeString("5a87133b68da3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f")
+	if err != nil {
+		t.Fatalf("Issue decoding seedStr")
+	}
+
+	//netStr := "192.122.190.0/24"
+	netStr := "2001:48a8:687f:1::/64"
+	_, net1, err := net.ParseCIDR(netStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr, err := SelectAddrFromSubnet(seed, net1)
+	if err != nil {
+		t.Fatal(err)
+	} else if addr.String() != "2001:48a8:687f:1:5fa4:c34c:434e:ddd" {
+		t.Fatalf("Wrong Address Selected: %v -> expected (%v)", addr, "2001:48a8:687f:1:5fa4:c34c:434e:ddd")
+	}
+
+}
+
+func TestSelectWeightedMany(t *testing.T) {
+
+	count := []int{0, 0}
+	loops := 1000
+	rand.Seed(12345)
+	_, net1, err := net.ParseCIDR("192.122.190.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, net2, err := net.ParseCIDR("141.219.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ps = SubnetConfig{
+		WeightedSubnets: []ConjurePhantomSubnet{
+			{Weight: 9, Subnets: []string{"192.122.190.0/24"}}, //curveball, ?
+			{Weight: 1, Subnets: []string{"141.219.0.0/16"}},   // windy-egret
+		},
+	}
+
+	for i := 1; i <= loops; i++ {
+		seed := make([]byte, 16)
+		_, err := rand.Read(seed)
+		if err != nil {
+			t.Fatalf("Failed to generate seed: %v", err)
+		}
+
+		addr, err := SelectPhantom(seed, ps, nil, true)
+		if err != nil {
+			t.Fatalf("Failed to select adddress: %v -- %s, %v, %v, %v -- %v", err, hex.EncodeToString(seed), ps, "None", true, count)
+		}
+
+		if net1.Contains(*addr) {
+			count[0]++
+		} else if net2.Contains(*addr) {
+			count[1]++
+		} else {
+			t.Fatalf("failed to parse SubnetConfig: %v, %v, %v", seed, true, ps)
+		}
+	}
+	t.Logf("%.2f%%, %.2f%%", float32(count[0])/float32(loops)*100.0, float32(count[1])/float32(loops)*100.0)
+}
+
+func TestWeightedSelection(t *testing.T) {
+
+	count := []int{0, 0}
+	loops := 1000
+	rand.Seed(5421212341231)
+
+	var ps = SubnetConfig{
+		WeightedSubnets: []ConjurePhantomSubnet{
+			{Weight: 9, Subnets: []string{"1"}}, //curveball, ?
+			{Weight: 1, Subnets: []string{"2"}}, // windy-egret
+		},
+	}
+
+	for i := 1; i <= loops; i++ {
+		seed := make([]byte, 16)
+		_, err := rand.Read(seed)
+		if err != nil {
+			t.Fatalf("Failed to generate seed: %v", err)
+		}
+
+		sa := ps.getSubnets(seed, true)
+		if sa == nil {
+			t.Fatalf("failed to parse SubnetConfig: %v, %v, %v", seed, true, ps)
+
+		} else if sa[0] == "1" {
+			count[0]++
+		} else if sa[0] == "2" {
+			count[1]++
+		}
+
+	}
+	t.Logf("%.2f%%, %.2f%%", float32(count[0])/float32(loops)*100.0, float32(count[1])/float32(loops)*100.0)
+}
+
+var phantomSubnets = SubnetConfig{
+	WeightedSubnets: []ConjurePhantomSubnet{
+		{Weight: 9, Subnets: []string{"192.122.190.0/24", "2001:48a8:687f:1::/64"}},
+		{Weight: 1, Subnets: []string{"141.219.0.0/16", "35.8.0.0/16"}},
+	},
+}
+
+func TestSelectFilter(t *testing.T) {
+	seed, err := hex.DecodeString("5a87133b68da3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f")
+	if err != nil {
+		t.Fatalf("Issue decoding seedStr")
+	}
+
+	p, err := SelectPhantomWeighted([]byte(seed), phantomSubnets, V4Only)
+	if err != nil {
+		t.Fatalf("Failed to select phantom: %v", err)
+	}
+	t.Logf("%v\n", p)
+
+	p, err = SelectPhantomWeighted([]byte(seed), phantomSubnets, V6Only)
+	if err != nil {
+		t.Fatalf("Failed to select phantom: %v", err)
+	}
+	t.Logf("%v\n", p)
+
+	p, err = SelectPhantomWeighted([]byte(seed), phantomSubnets, nil)
+	if err != nil {
+		t.Fatalf("Failed to select phantom: %v", err)
+	}
+	t.Logf("%v\n", p)
+}


### PR DESCRIPTION
Implement address selection as its own module 

Adds: 
- weighted subnet list selection. 
- testing internal to the phantom selection module.
- more streamlined phantom selection algorithm

I may add another commit to clean up comments.