### PR TITLE
Add optional custom TcpDialer for DecoyRegistrar

### DIFF
--- a/tapdance/dialer.go
+++ b/tapdance/dialer.go
@@ -85,6 +85,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 				return nil, err
 			}
 			flow.tdRaw.TcpDialer = d.TcpDialer
+			flow.tdRaw.useProxyHeader = d.UseProxyHeader
 			return flow, flow.DialContext(ctx)
 		} else {
 			// _, err := makeTdFlow(flowBidirectional, nil, address)

--- a/tapdance/phantoms/phantoms.go
+++ b/tapdance/phantoms/phantoms.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"math/big"
 	"math/rand"
 	"net"
@@ -212,7 +211,7 @@ func SelectPhantom(seed []byte, subnets SubnetConfig, transform SubnetFilter, we
 
 	s, err := parseSubnets(subnets.getSubnets(seed, weighted))
 	if err != nil {
-		log.Fatalf("Failed to parse subnets: %v", err)
+		return nil, fmt.Errorf("Failed to parse subnets: %v", err)
 	}
 
 	if transform != nil {


### PR DESCRIPTION
- This enables distinct treatments of TCP connections
  created by the DecoyRegistrar vs. the phantom dial,
  which continues to use Dialer.TcpDialer.

- Also modify SelectPhantom to not terminate the process
  when parseSubnets fails; instead simply return an error.