### PR TITLE
Conjure Probe Tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -25,6 +25,14 @@ Client Config management tools. Used for adding
 
 Perform a AAAA lookup for each domain name as part of clientConfig supplement for Conjure.
 
+## CJProbe
+
+`cjprobe`
+
+Run UDP probe tool to test station reachability. Sends raw UDP packets or DNS requests containing
+string tag the conjure stations look for and log, validating that a station lies on path for a
+client, server pair.
+
 ## Elligator Test
 
 `elligator-test`

--- a/tools/cjprobe/README.md
+++ b/tools/cjprobe/README.md
@@ -1,0 +1,76 @@
+
+# Conjure Prober
+
+This tool is a testing system for measuring conjure station reachability. Each station watches for
+UDP packets containing a special string, and logs source and destination IP addresses when it is
+detected. This allows a station operator to run this tool from disparate locations and validate that
+traffic routes past a designated station. [Station string checking](https://github.com/refraction-networking/conjure/blob/da349002ae89bf05b3fa2a3197ae2d3b8eefa3f9/src/process_packet.rs#L353)
+can be seen here.
+
+For compatibility with RIPE atlas this was designed be sent as a DNS lookup
+request with the special string as the domain. In this tool we send the DNS encoded version of the
+tag as a raw UDP packet. This tool does provide the option `-dns` which causes this tool to use
+the golang DNS lookup system but this is not the default behavior.
+
+In general UDP was chosen because it allows us to send the packet without participation on the side of the
+target address. This allows us to validate Phantom addresses even if no host resides at the address
+(which would be impossible for any TCP based probe).
+
+## Usage
+
+```sh
+cjprobe [options] [TARGETS...]:
+  -d    Only scan decoy addresses, ignore subnets from clientconf or command line args
+  -dns
+        Send the tag as a DNS request (uses golang DNS lookup sending 8 probes)
+  -f ClientConf
+        ClientConf file to parse
+  -no6
+        Ignore IPv6 decoys and subnets when probing
+  -p int
+        Destination port of all probes sent (default 53)
+  -q    Quiet mode - prevents probe result logging
+  -s    Only scan subnet blocks, ignore decoys from clientconf or command line args
+  -sa int
+        Number of addresses to choose from each subnet (default 1)
+  -ss int
+        Seed for random selection of address from subnet blocks (default -1)
+  -tag string
+        Set a custom tag to be sent over the probe. Only works with raw UDP packet mode
+  -url string
+        Set a custom domain string for DNS lookup. Only works with DNS request mode
+  -w int
+        Number of parallel workers for the connect_to_all test (default 20)
+```
+
+For example to scan all decoys from a given clientconf you could run the following. Currently
+phantom subnets CAN be stored in the Clientconf struct, but no distributed ClientConf contains
+phantom subnets (this will come soon).
+
+```sh
+cjprobe -f ../assets/ClientConf
+```
+
+Subnets and decoy address targets can also be specified in the tailing args. To perform a scan that
+uses 5 addresses from each phantom subnet provided chosen in a reproducible way we can use the `-sa`
+option to set the `addresses-per-subnet` and the `-ss` option to set the `subnet-seed`. This selects
+from two subnets, supporting ipv4 and ipv6.
+
+```sh
+cjprobe -sa 5 -ss 100 10.0.0.1/8 2106:abcd::1/32
+```
+
+To send a DNS query we can provide the `-dns` flag. Note that when
+using the `-dns` option that there is no control over retries, so addresses not running public
+DNS resolvers will force golang to send 8 DNS requests per address. As shown below we can also mix
+our tailing targets between subnets and decoy addresses.
+
+```sh
+cjprobe -dns 8.8.8.8 1.1.1.1 128.138.0.1/16
+```
+
+## Notes
+
+Many clientconfigs have duplicate decoy addresses as there are multiple domain names that reference
+the same decoy IP address. This tool automatically de-duplicates before sending probes, so the probe
+function is only called once for each address.

--- a/tools/cjprobe/cjprobe.go
+++ b/tools/cjprobe/cjprobe.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/refraction-networking/gotapdance/protobuf"
+	log "github.com/sirupsen/logrus"
+)
+
+var specialUDPEncoded = "\x38xCKe9ECO5lNwXgd5Q25w0C2qUR7whltkA8BbyNokGIp5rzzm0hc7yqbR\x38FAP3S9w7oLrvvei7IphdwZEKUvF5iZeSdtDFEDc6cIDiv11aTNkOp08k\x38mRISHvoeSWSgMOjkbR2un5XKpJEZIK31Bc2obUGRIoY2tpxm6RUV5nOU\x07SuifuqZ"
+var specialUDPPayload = "xCKe9ECO5lNwXgd5Q25w0C2qUR7whltkA8BbyNokGIp5rzzm0hc7yqbR.FAP3S9w7oLrvvei7IphdwZEKUvF5iZeSdtDFEDc6cIDiv11aTNkOp08k.mRISHvoeSWSgMOjkbR2un5XKpJEZIK31Bc2obUGRIoY2tpxm6RUV5nOU.SuifuqZ"
+var specialUDPPort = 53
+
+func main() {
+
+	decoyOnly := flag.Bool("d", false, "Only scan decoy addresses, ignore subnets from clientconf or command line args")
+	subnetOnly := flag.Bool("s", false, "Only scan subnet blocks, ignore decoys from clientconf or command line args")
+	addressesPerSubnet := flag.Int("sa", 1, "Number of addresses to choose from each subnet")
+	subnetSeed := flag.Int64("ss", -1, "Seed for random selection of address from subnet blocks")
+
+	excludeV6 := flag.Bool("no6", false, "Ignore IPv6 decoys and subnets when probing")
+
+	workers := flag.Int("w", 20, "Number of parallel workers for the connect_to_all test")
+
+	fname := flag.String("f", "", "`ClientConf` file to parse")
+	port := flag.Int("p", 53, "Destination port of all probes sent")
+
+	quiet := flag.Bool("q", false, "Quiet mode - prevents probe result logging")
+
+	customTag := flag.String("tag", "", "Set a custom tag to be sent over the probe. Only works with raw UDP packet mode")
+	customURL := flag.String("url", "", "Set a custom domain string for DNS lookup. Only works with DNS request mode")
+
+	useDNS := flag.Bool("dns", false, "Send the tag as a DNS request (uses golang DNS lookup sending 8 probes)")
+
+	flag.Parse()
+
+	// Quick compatibility check
+	if *decoyOnly && *subnetOnly {
+		log.Warn("Decoy only (-d) and Subnet only (-s) conflict, use only one.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Set the payload and port if they were set by command line arg
+	if *customURL != "" {
+		specialUDPPayload = *customURL
+	}
+	if *customTag != "" {
+		specialUDPEncoded = *customTag
+	}
+	if *port != 53 {
+		specialUDPPort = *port
+	}
+
+	var targets = []string{}
+	var subnets = []*net.IPNet{}
+
+	// parse args as decoy addresses or subnets
+	for _, arg := range flag.Args() {
+		_, subnet, err := net.ParseCIDR(arg)
+		if err == nil {
+			if !*decoyOnly {
+				subnets = append(subnets, subnet)
+			}
+		} else if addr := net.ParseIP(arg); addr != nil {
+			if !*subnetOnly {
+				targets = append(targets, addr.String())
+			}
+		} else {
+			if !*quiet {
+				log.Warnf("failed to parse target \"%s\"", arg)
+			}
+		}
+	}
+
+	// parse decoys from clientconf into string array
+	var clientConf *pb.ClientConf
+	var err error
+	if *fname != "" {
+		clientConf, err = parseClientConf(*fname)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !*subnetOnly {
+			for _, decoy := range clientConf.GetDecoyList().TlsDecoys {
+				// Decoy string includes port which we do not want
+				addr := strings.Split(decoy.GetIpAddrStr(), ":")[0]
+				targets = append(targets, addr)
+			}
+		}
+		if !*decoyOnly {
+			if blocks := clientConf.GetDarkDecoyBlocks(); blocks != nil {
+				for _, subnetStr := range blocks.Blocks {
+					_, subnet, err := net.ParseCIDR(subnetStr)
+					if err != nil {
+						continue
+					}
+					subnets = append(subnets, subnet)
+				}
+			}
+		}
+	}
+	// select random addresses from subnets
+	targets = append(targets, selectFromSubnets(subnets, *addressesPerSubnet, *subnetSeed)...)
+
+	// de-duplicate addresses in list
+	targets = removeDuplicateValues(targets)
+
+	// Exclude v6 addresses if option is specified.
+	if *excludeV6 {
+		log.Info("excluding IPv6 targets")
+		targets = removeIPv6Addrs(targets)
+	}
+
+	// fmt.Printf("so: %v, sa: %v, ss:%v, do:%v, no6:%v, wrkrs:%d, cc:%s, p: %v, q: %v, args: %+v\n",
+	// 	*subnetOnly, *addressesPerSubnet, *subnetSeed, *decoyOnly, *excludeV6, *workers, *fname, *port, *quiet, flag.Args())
+
+	// fmt.Println(targets, subnets)
+	ConnectToAll(targets, *workers, *quiet, *useDNS)
+}
+
+func parseClientConf(fname string) (*pb.ClientConf, error) {
+
+	clientConf := pb.ClientConf{}
+	buf, err := ioutil.ReadFile(fname)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading file - %v", err)
+	}
+	err = proto.Unmarshal(buf, &clientConf)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing ClientConf - %v", err)
+	}
+	return &clientConf, nil
+}
+
+type jobTuple struct {
+	Target string
+	Total  uint
+	JobID  uint
+}
+
+// ConnectToAll parallelizes the process pg sending tagged packets to hosts.
+func ConnectToAll(targets []string, workers int, quiet bool, useDNS bool) {
+
+	if !quiet {
+		log.Info("Connection to all registration decoys in client conf.")
+	}
+	var wg sync.WaitGroup
+
+	jobChan := make(chan jobTuple, len(targets))
+
+	for id := 0; id < workers; id++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			jobsCompleted := 0
+			var err error
+
+			for jobTuple := range jobChan {
+
+				target := jobTuple.Target
+				output := fmt.Sprintf("[%d/%d/%d] (%d) Connecting to decoy %s ... ",
+					jobsCompleted, jobTuple.JobID, jobTuple.Total, id, target)
+
+				start := time.Now()
+				if useDNS {
+					err = ConnectSpecialDNS(target, specialUDPPayload)
+				} else {
+					err = ConnectSpecial(target, specialUDPEncoded)
+				}
+				duration := time.Since(start)
+				if !quiet {
+					if err != nil {
+						output += fmt.Sprintf("%d Failure: %s\n", duration.Milliseconds(), err.Error())
+						log.Warn(output)
+					} else {
+						output += fmt.Sprintf("%d Success\n", duration.Milliseconds())
+						log.Info(output)
+					}
+				}
+				jobsCompleted++
+			}
+
+		}(id) // end go worker func
+	}
+
+	go func() {
+		total := uint(len(targets))
+		for idx, target := range targets {
+			jobChan <- jobTuple{Target: target, Total: total, JobID: uint(idx)}
+		}
+		close(jobChan)
+	}()
+
+	wg.Wait()
+}
+
+// ConnectSpecial sends a raw UDP packet with the tag specified. `target` must be an IP address.
+func ConnectSpecial(target, tag string) error {
+	conn, err := net.Dial("udp", net.JoinHostPort(target, fmt.Sprint(specialUDPPort)))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, tag)
+
+	return nil
+}
+
+func removeDuplicateValues(strSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+
+	// If the key(values of the slice) is not equal
+	// to the already present value in new slice (list)
+	// then we append it. else we jump on another element.
+	for _, entry := range strSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
+func removeIPv6Addrs(addrSlice []string) []string {
+	return []string{}
+}
+
+// ConnectSpecialDNS sends the special tag as a DNS request and ignores any response. This uses
+// The golang DNS resolution, so it may result in retries or longer timeouts as we do not expect
+// targets to actually function as DNS resolvers.
+func ConnectSpecialDNS(target, tag string) error {
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: time.Millisecond * time.Duration(10000),
+			}
+			return d.DialContext(ctx, "udp", net.JoinHostPort(target, fmt.Sprint(specialUDPPort)))
+		},
+	}
+	_, err := r.LookupHost(context.Background(), tag)
+	return err
+}
+
+func selectFromSubnets(subnets []*net.IPNet, aps int, seed int64) []string {
+	list := []string{}
+
+	if seed != -1 {
+		rand.Seed(seed)
+	}
+	for _, subnet := range subnets {
+		for i := 0; i < aps; i++ {
+
+			randomBytes := make([]byte, len(subnet.IP))
+			_, err := rand.Read(randomBytes)
+			if err != nil {
+				continue
+			}
+
+			addressBytes := subnet.IP.Mask(subnet.Mask)
+			newAddr := []byte{}
+			for idx, b := range subnet.Mask {
+				randMask := randomBytes[idx] & (^b)
+				newAddr = append(newAddr, randMask|addressBytes[idx])
+			}
+
+			addr := net.IP(newAddr).String()
+			list = append(list, addr)
+		}
+	}
+
+	return list
+}

--- a/tools/cjprobe/cjprobe_test.go
+++ b/tools/cjprobe/cjprobe_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestCJProbeSelectFromSubnet(t *testing.T) {
+	subnetStrings := []string{"10.0.0.1/8", "128.138.0.0/16"}
+	var seed int64 = 1000
+
+	strToNet := func(s []string) []*net.IPNet {
+		list := []*net.IPNet{}
+		for _, str := range s {
+			_, subnet, err := net.ParseCIDR(str)
+			if err != nil {
+				t.Fatal(err)
+			}
+			list = append(list, subnet)
+		}
+		return list
+	}
+
+	selected := selectFromSubnets(strToNet(subnetStrings), 1, seed)
+	if len(selected) != 2 {
+		t.FailNow()
+	} else if selected[0] != "10.138.86.216" || selected[1] != "128.138.31.3" {
+		t.FailNow()
+	}
+
+	subnetStrings = []string{"fe80::/32"}
+	selected = selectFromSubnets(strToNet(subnetStrings), 1, seed)
+	if len(selected) != 1 {
+		t.FailNow()
+	} else if selected[0] != "fe80:0:b5fb:1f03:8ffb:fce7:9f18:5f4a" {
+		t.FailNow()
+	}
+
+	subnetStrings = []string{"fe80::/32", "10.0.0.1/8"}
+	selected = selectFromSubnets(strToNet(subnetStrings), 2, seed)
+	if len(selected) != 4 {
+		t.FailNow()
+	} else if selected[0] != "fe80:0:b5fb:1f03:8ffb:fce7:9f18:5f4a" ||
+		selected[1] != "fe80:0:94ed:b854:57d6:c84d:6bc0:2a82" ||
+		selected[2] != "10.78.228.45" ||
+		selected[3] != "10.30.156.59" {
+		t.FailNow()
+	}
+}

--- a/tools/makefile
+++ b/tools/makefile
@@ -3,7 +3,7 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
-BINARY_NAMES=clientconf v6lookup elligator-test utls-test
+BINARY_NAMES=clientconf v6lookup elligator-test utls-test cjprobe
 
 
 all: test build
@@ -23,6 +23,11 @@ clientconf:
 v6lookup:
 	echo "building v6lookup"; \
 	cd v6lookup && $(GOBUILD) -o ../bin/v6lookup ; \
+	cd ../; \
+
+cjprobe:
+	echo "building conjure probe tool"; \
+	cd cjprobe && $(GOBUILD) -o ../bin/cjprobe ; \
 	cd ../; \
 
 elligator-test:


### PR DESCRIPTION
## Problem 
It is difficult to debug routing issues. In a high throughput traffic environment logging all throughput is not realistic.

## Solution
Send a specially crafted UDP packet from a variety of test locations, and have stations look for those explicitly tagged flows. This tool implements the client side of that process and supports a variety of probing parameters including clientconf parsing.

See `tools/cjprobe/README.md` for more information about usage and implementation. 

- [x] Tested Working for Raw UDP and golang based DNS requests.