### PR TITLE
Updates to tools/clientconfig/clientconfig.go: Added add-subnet, dele…

### DIFF
--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -127,13 +127,8 @@ func addSubnets(subnets []string, weight *uint, clientConf *pb.ClientConf) {
 		}
 	}
 	var weight32 = uint32(*weight)
-	for _, phantomSubnets := range clientConf.PhantomSubnetsList.WeightedSubnets {
-		if *phantomSubnets.Weight == weight32 {
-			phantomSubnets.Subnets = append(phantomSubnets.Subnets, subnets...)
-			return
-		}
-	}
-	// add new item to PhantomSubnetsList.WeightedSubnets if weight has not been used before
+	
+	// add new item to PhantomSubnetsList.WeightedSubnets
 	var newPhantomSubnet = pb.PhantomSubnets{
 		Weight:  &weight32,
 		Subnets: subnets,


### PR DESCRIPTION
…te-subnet, and subnet-file commands to manually add/delete subnets from conf. Subnet-file takes path to a TOML file, parses it into a PhantomSubnetsList, and uses it to replace the subnet list of the current file. Removed hard-coded subnet specificaition.