### PR TITLE
Protobuf: WebRTC Transport Support

### DIFF
--- a/protobuf/signalling.proto
+++ b/protobuf/signalling.proto
@@ -141,6 +141,20 @@ enum TransportType {
     Null = 0;
     Min = 1;   // Send a 32-byte HMAC id to let the station distinguish registrations to same host
     Obfs4 = 2; // Not implemented yet?
+    Webrtc = 3; // UDP transport: WebRTC DataChannel
+}
+
+message WebrtcSDP {
+    optional uint32 sdp_type = 1; // TODO: Single byte (uint8)
+    // the IP is represented as a 16-byte datatype.
+    optional uint64 ip_upper = 2; // ip := upper << 64 | lower
+    optional uint64 ip_lower = 3;
+    optional uint32 composed_info = 4;
+}
+
+message WebrtcSignalling {
+    repeated WebrtcSDP webrtc_sdps = 1;
+    optional string webrtc_seed = 2;
 }
 
 message StationToClient {
@@ -218,6 +232,9 @@ message ClientToStation {
     // A collection of optional flags for the registration.
     optional RegistrationFlags flags = 24;
 
+    // Transport Extensions
+    optional WebrtcSignalling webrtc_signalling = 31;
+    
     // Random-sized junk to defeat packet size fingerprinting.
     optional bytes padding = 100;
 }


### PR DESCRIPTION
- Modified protobuf definition for gotapdance to support WebRTC DataChannel Transport.