### PR TITLE
Add library function to set logger output

### DIFF
--- a/tapdance/logger.go
+++ b/tapdance/logger.go
@@ -2,6 +2,7 @@ package tapdance
 
 import (
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -34,4 +35,10 @@ func Logger() *logrus.Logger {
 		}
 	})
 	return logrusLogger
+}
+
+// SetLoggerOutput will allow a caller to change the Logger output from the
+// default of os.Stderr
+func SetLoggerOutput(out io.Writer) {
+	Logger().SetOutput(out)
 }


### PR DESCRIPTION
By default logrus will write output to stderr. This change allows a
caller of the library to change the log output to any io.Writer.

Closes #88

See the WIP [tor conjure PT](https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/conjure/-/blob/72f424edfd664a9b103c664404d32f23c46131ec/conjure.go#L98) for an example of how it's used.