### PR TITLE
Fix ClientConf update issues

### DIFF
--- a/tapdance/assets.go
+++ b/tapdance/assets.go
@@ -332,9 +332,11 @@ func (a *assets) SetClientConf(conf *pb.ClientConf) (err error) {
 	a.Lock()
 	defer a.Unlock()
 
+	origConf := a.config
+	a.config = conf
 	err = a.saveClientConf()
-	if err == nil {
-		a.config = conf
+	if err != nil {
+		a.config = origConf
 	}
 	return
 }

--- a/tapdance/registrar_bidirectional.go
+++ b/tapdance/registrar_bidirectional.go
@@ -197,7 +197,7 @@ func (r APIRegistrarBidirectional) unpackRegResp(reg *ConjureReg, regResp *pb.Re
 
 	// Client config -- check if not nil in the registration response
 	if regResp.GetClientConf() != nil {
-		currGen := Assets().config.GetGeneration()
+		currGen := Assets().GetGeneration()
 		incomingGen := regResp.GetClientConf().GetGeneration()
 		Logger().Debugf("received clientconf in regResponse w/ gen %d", incomingGen)
 		if currGen < incomingGen {


### PR DESCRIPTION
- Save the new conf in SetClientConf. Fixes
  https://github.com/refraction-networking/gotapdance/issues/83.

- Use Assets().GetGeneration() to avoid the race condition that results
  from accessing Assets().config directly.