### PR TITLE
Automatically try different registrars

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -158,6 +158,20 @@ func connectDirect(td bool, apiEndpoint string, registrar string, connect_target
 		if err != nil {
 			return fmt.Errorf("error creating DNS registrar: [%v]", err)
 		}
+	} else if registrar == "auto" {
+		autoRegistrar, err := tapdance.NewAutoRegistrar()
+		if err != nil {
+			return fmt.Errorf("error creating auto registrar: %w", err)
+		}
+
+		tdDialer.DarkDecoyRegistrar = autoRegistrar
+	} else if registrar == "bdauto" {
+		autoRegistrar, err := tapdance.NewBdAutoRegistrar()
+		if err != nil {
+			return fmt.Errorf("error creating auto registrar: %w", err)
+		}
+
+		tdDialer.DarkDecoyRegistrar = autoRegistrar
 	} else if registrar == "decoy" {
 		// Done
 	} else {

--- a/tapdance/auto-registrar.go
+++ b/tapdance/auto-registrar.go
@@ -44,14 +44,14 @@ func NewAutoRegistrar() (*AutoRegistrar, error) {
 		MaxRetries:      retriesPerRegistrar,
 	})
 
+	registrars = append(registrars, DecoyRegistrar{})
+
 	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, false, connectionDelay, retriesPerRegistrar, dnsConf.GetPubkey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNS registrar: %w", err)
 	}
 
 	registrars = append(registrars, dnsRegistrar)
-
-	registrars = append(registrars, DecoyRegistrar{})
 
 	return &AutoRegistrar{
 		registrars: registrars,

--- a/tapdance/auto-registrar.go
+++ b/tapdance/auto-registrar.go
@@ -44,14 +44,14 @@ func NewAutoRegistrar() (*AutoRegistrar, error) {
 		MaxRetries:      retriesPerRegistrar,
 	})
 
-	registrars = append(registrars, DecoyRegistrar{})
-
 	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, false, connectionDelay, retriesPerRegistrar, dnsConf.GetPubkey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNS registrar: %w", err)
 	}
 
 	registrars = append(registrars, dnsRegistrar)
+
+	registrars = append(registrars, DecoyRegistrar{})
 
 	return &AutoRegistrar{
 		registrars: registrars,

--- a/tapdance/auto-registrar.go
+++ b/tapdance/auto-registrar.go
@@ -23,13 +23,6 @@ type AutoRegistrar struct {
 // NewAutoRegistrar creates an AutoRegistrar from configuration stored in assets
 func NewAutoRegistrar() (*AutoRegistrar, error) {
 	registrars := []Registrar{}
-	registrars = append(registrars, DecoyRegistrar{})
-
-	registrars = append(registrars, APIRegistrarBidirectional{
-		Endpoint:        bdApiEndpoint,
-		ConnectionDelay: connectionDelay,
-		MaxRetries:      retriesPerRegistrar,
-	})
 
 	dnsConf := Assets().GetDNSRegConf()
 	bdDnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, true, connectionDelay, retriesPerRegistrar, dnsConf.GetPubkey())
@@ -39,11 +32,19 @@ func NewAutoRegistrar() (*AutoRegistrar, error) {
 
 	registrars = append(registrars, bdDnsRegistrar)
 
+	registrars = append(registrars, APIRegistrarBidirectional{
+		Endpoint:        bdApiEndpoint,
+		ConnectionDelay: connectionDelay,
+		MaxRetries:      retriesPerRegistrar,
+	})
+
 	registrars = append(registrars, APIRegistrar{
 		Endpoint:        apiEndpoint,
 		ConnectionDelay: connectionDelay,
 		MaxRetries:      retriesPerRegistrar,
 	})
+
+	registrars = append(registrars, DecoyRegistrar{})
 
 	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, false, connectionDelay, retriesPerRegistrar, dnsConf.GetPubkey())
 	if err != nil {

--- a/tapdance/auto-registrar.go
+++ b/tapdance/auto-registrar.go
@@ -1,0 +1,77 @@
+package tapdance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// AutoRegistrar stores multiple registrars and calls each until a success
+type AutoRegistrar struct {
+	registrars []Registrar
+}
+
+// NewAutoRegistrar creates an AutoRegistrar from configuration stored in assets
+func NewAutoRegistrar() (*AutoRegistrar, error) {
+	registrars := []Registrar{}
+	registrars = append(registrars, DecoyRegistrar{})
+
+	apiEndpoint := "https://registration.refraction.network/api/register" // will be configured via ClientConf in the future
+	registrars = append(registrars, APIRegistrar{
+		Endpoint:        apiEndpoint,
+		ConnectionDelay: 750 * time.Millisecond,
+		MaxRetries:      3,
+	})
+
+	dnsConf := Assets().GetDNSRegConf()
+	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, false, 750*time.Millisecond, 3, Assets().GetConjurePubkey()[:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DNS registrar: %w", err)
+	}
+
+	registrars = append(registrars, dnsRegistrar)
+
+	return &AutoRegistrar{
+		registrars: registrars,
+	}, nil
+}
+
+// NewBdAutoRegistrar creates an bidirectional AutoRegistrar from configuration stored in assets
+func NewBdAutoRegistrar() (*AutoRegistrar, error) {
+	registrars := []Registrar{}
+
+	// URL for API registrar, will be configured via ClientConf in the future
+	apiEndpoint := "https://registration.refraction.network/api/register-bidirectional" // will be configured via ClientConf in the future
+	registrars = append(registrars, APIRegistrarBidirectional{
+		Endpoint:        apiEndpoint,
+		ConnectionDelay: 750 * time.Millisecond,
+		MaxRetries:      3,
+	})
+
+	dnsConf := Assets().GetDNSRegConf()
+	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, true, 750*time.Millisecond, 3, Assets().GetConjurePubkey()[:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DNS registrar: %w", err)
+	}
+
+	registrars = append(registrars, dnsRegistrar)
+
+	return &AutoRegistrar{
+		registrars: registrars,
+	}, nil
+}
+
+// Register calls the underlying registrars to register
+func (r AutoRegistrar) Register(cjSession *ConjureSession, ctx context.Context) (*ConjureReg, error) {
+	for _, registrar := range r.registrars {
+		conjReg, err := registrar.Register(cjSession, ctx)
+		if err != nil {
+			Logger().Debugf("Auto registration failed: %v", err)
+			continue
+		}
+		return conjReg, nil
+	}
+
+	return nil, errors.New("auto registration failed: no working registrar")
+}

--- a/tapdance/auto-registrar.go
+++ b/tapdance/auto-registrar.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+const (
+	// consider moving to ClientConf
+	apiEndpoint         = "https://registration.refraction.network/api/register"
+	bdApiEndpoint       = "https://registration.refraction.network/api/register-bidirectional"
+	connectionDelay     = 750 * time.Millisecond
+	retriesPerRegistrar = 1
+)
+
 // AutoRegistrar stores multiple registrars and calls each until a success
 type AutoRegistrar struct {
 	registrars []Registrar
@@ -17,40 +25,27 @@ func NewAutoRegistrar() (*AutoRegistrar, error) {
 	registrars := []Registrar{}
 	registrars = append(registrars, DecoyRegistrar{})
 
-	apiEndpoint := "https://registration.refraction.network/api/register" // will be configured via ClientConf in the future
-	registrars = append(registrars, APIRegistrar{
-		Endpoint:        apiEndpoint,
-		ConnectionDelay: 750 * time.Millisecond,
-		MaxRetries:      3,
+	registrars = append(registrars, APIRegistrarBidirectional{
+		Endpoint:        bdApiEndpoint,
+		ConnectionDelay: connectionDelay,
+		MaxRetries:      retriesPerRegistrar,
 	})
 
 	dnsConf := Assets().GetDNSRegConf()
-	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, false, 750*time.Millisecond, 3, Assets().GetConjurePubkey()[:])
+	bdDnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, true, connectionDelay, retriesPerRegistrar, dnsConf.GetPubkey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNS registrar: %w", err)
 	}
 
-	registrars = append(registrars, dnsRegistrar)
+	registrars = append(registrars, bdDnsRegistrar)
 
-	return &AutoRegistrar{
-		registrars: registrars,
-	}, nil
-}
-
-// NewBdAutoRegistrar creates an bidirectional AutoRegistrar from configuration stored in assets
-func NewBdAutoRegistrar() (*AutoRegistrar, error) {
-	registrars := []Registrar{}
-
-	// URL for API registrar, will be configured via ClientConf in the future
-	apiEndpoint := "https://registration.refraction.network/api/register-bidirectional" // will be configured via ClientConf in the future
-	registrars = append(registrars, APIRegistrarBidirectional{
+	registrars = append(registrars, APIRegistrar{
 		Endpoint:        apiEndpoint,
-		ConnectionDelay: 750 * time.Millisecond,
-		MaxRetries:      3,
+		ConnectionDelay: connectionDelay,
+		MaxRetries:      retriesPerRegistrar,
 	})
 
-	dnsConf := Assets().GetDNSRegConf()
-	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, true, 750*time.Millisecond, 3, Assets().GetConjurePubkey()[:])
+	dnsRegistrar, err := NewDNSRegistrarFromConf(dnsConf, false, connectionDelay, retriesPerRegistrar, dnsConf.GetPubkey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DNS registrar: %w", err)
 	}


### PR DESCRIPTION
This PR adds a default 'auto' type of registrar, which tries to use the available registrars one at a time and tries another if one fails, until one succeeds or all the registrars have failed. It does so in the following order: bddns, bdapi, api, decoy, dns. 