### PR TITLE
Actually make sleepBeforeConnect() implement an exponential backoff

### DIFF
--- a/tapdance/common.go
+++ b/tapdance/common.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -171,8 +172,9 @@ func WriteTlsLog(clientRandom, masterSecret []byte) error {
 
 // How much time to sleep on trying to connect to decoys to prevent overwhelming them
 func sleepBeforeConnect(attempt int) (waitTime <-chan time.Time) {
-	if attempt >= 6 { // return nil for first 6 attempts
-		waitTime = time.After(time.Second * 1)
+	if attempt >= 1 {
+		ms := math.Min(25*math.Pow(2, float64(attempt)), 15000)
+		waitTime = time.After(time.Duration(int(ms)) * time.Millisecond)
 	}
 	return
 }


### PR DESCRIPTION
Currently, our sleepBeforeConnect() doesn't sleep for the first 6 connections, but then sleeps 1 second between retries after that.

That's too overwhelming, and not an exponential backoff. This change increases the exponential backoff to be 25*(2^n) milliseconds, up to 15 seconds, for retry n.

We may want to even increase the upper bound (15 seconds) to something larger (or remove the upper bound entirely)