### PR TITLE
Features for robots-only pipeline

### DIFF
--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -437,6 +437,7 @@ func main() {
 		"The file has to be in the following format:\n"+
 		"ip,sni\n",
 	)
+	var print_pairs = flag.Bool("print-pairs", false, "Print pairs of decoys ip,sni")
 
 	flag.Parse()
 
@@ -445,6 +446,23 @@ func main() {
 	// Parse ClientConf
 	if *fname != "" {
 		clientConf = parseClientConf(*fname)
+	}
+
+	// Print pairs of decoy addresses
+	if *print_pairs {
+		ip := ""
+		for _, decoy := range clientConf.DecoyList.TlsDecoys {
+			decoy_ip4 := make(net.IP, 4)
+			binary.BigEndian.PutUint32(decoy_ip4, decoy.GetIpv4Addr())
+			decoy_ip6 := net.IP(decoy.GetIpv6Addr())
+			
+			if decoy_ip4.To4().String() != "0.0.0.0" {
+				ip = decoy_ip4.To4().String()
+			} else {
+				ip = decoy_ip6.To16().String()
+			}
+			fmt.Printf("%s,%s\n", ip, decoy.GetHostname())
+		}
 	}
 
 	// Use subnet-file

--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -424,6 +424,7 @@ func main() {
 	var fname = flag.String("f", "", "`ClientConf` file to parse")
 	var out_fname = flag.String("o", "", "`output` file name to write new/modified config")
 	var generation = flag.Int("generation", 0, "New/modified generation")
+	var next_gen = flag.Bool("next-gen", false, "Assign the next generation number to the created ClientConf based on the provided one")
 	var pubkey = flag.String("pubkey", "", "New/modified (decoy) pubkey. If -add or -update, applies to specific decoy. If -all applies to all decoys. Otherwise, applies to default pubkey.")
 	var cjPubkey = flag.String("cjpubkey", "", "New/modified (decoy) conjure pubkey. If -add or -update, applies to specific decoy. If -all applies to all decoys. Otherwise, applies to default pubkey.")
 	var delpubkey = flag.Bool("delpubkey", false, "Delete pubkey from decoy with index specified in -update (or from all decoys if -all)")
@@ -518,6 +519,10 @@ func main() {
 	// Update generation
 	if *generation != 0 {
 		gen := uint32(*generation)
+		clientConf.Generation = &gen
+	} else if *next_gen {
+		gen := clientConf.GetGeneration()
+		gen++
 		clientConf.Generation = &gen
 	}
 


### PR DESCRIPTION
This PR does two things to `tools/clientconf/clientconf.go`:

a. Replaces the deprecated tree.Unmarshal in toml go library with toml.Unmarshal to read a (weighted) subnets file (subnet-file option) and add it to the ClientConf

b. Adds features to facilitate running a pipeline that 1. checks whether decoys disallowed tapdance in their robots.txt, and 2. produces a ClientConf that excludes such decoys. These features help avoid having separate scripts that would read and reformat ClientConf printed contents.
The features are as follows:
    - print-pairs: adding a flag and functionality that allows clientconf.go to print "ip,sni" pairs for the decoys in the provided ClientConf. (These pairs will be the input to robots.go or robots.py).
    - rm-decoys: adding a flag and functionality that allows clientconf.go to read a file of "ip,sni" lines and remove the matching decoys from the provided ClientConf.
    - next-gen: adding a flag and functionality that assigns the next generation number (current generation number from provided ClientConf + 1) to the ClientConf being printed/produced.
