### PR TITLE
Allow cli to specify a particular phantom subnet

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -48,6 +48,8 @@ func main() {
 	var registrar = flag.String("registrar", "decoy", "One of decoy, api, bdapi, dns, bddns.")
 	var transport = flag.String("transport", "min", `The transport to use for Conjure connections. Current values include "min" and "obfs4".`)
 
+	var phantomNet = flag.String("phantom", "", "Target phantom subnet. Must overlap with ClientConf, and will be achieved by brute force of seeds until satisified")
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Dark Decoy CLI\n$./cli -connect-addr=<decoy_address> [OPTIONS] \n\nOptions:\n")
 		flag.PrintDefaults()
@@ -96,7 +98,7 @@ func main() {
 		fmt.Printf("Using Station Pubkey: %s\n", hex.EncodeToString(tapdance.Assets().GetConjurePubkey()[:]))
 	}
 
-	err := connectDirect(*td, *APIRegistration, *registrar, *connect_target, *port, *proxyHeader, v6Support, *width, *transport)
+	err := connectDirect(*td, *APIRegistration, *registrar, *connect_target, *port, *proxyHeader, v6Support, *width, *transport, *phantomNet)
 	if err != nil {
 		tapdance.Logger().Println(err)
 		os.Exit(1)
@@ -112,7 +114,7 @@ func main() {
 		}*/
 }
 
-func connectDirect(td bool, apiEndpoint string, registrar string, connect_target string, localPort int, proxyHeader bool, v6Support bool, width int, transport string) error {
+func connectDirect(td bool, apiEndpoint string, registrar string, connect_target string, localPort int, proxyHeader bool, v6Support bool, width int, transport string, phantomNet string) error {
 	if _, _, err := net.SplitHostPort(connect_target); err != nil {
 		return fmt.Errorf("failed to parse host and port from connect_target %s: %v",
 			connect_target, err)
@@ -130,6 +132,7 @@ func connectDirect(td bool, apiEndpoint string, registrar string, connect_target
 		V6Support:          v6Support,
 		Width:              width,
 		Transport:          getTransportFromName(transport),
+		PhantomNet:         phantomNet,
 	}
 
 	switch registrar {

--- a/tapdance/conjure.go
+++ b/tapdance/conjure.go
@@ -74,7 +74,7 @@ func DialConjure(ctx context.Context, cjSession *ConjureSession, registrationMet
 		return nil, fmt.Errorf("No Session Provided")
 	}
 
-	cjSession.setV6Support(both)
+	//cjSession.setV6Support(both)	 // We don't want to override this here; defaults set in MakeConjureSession
 
 	// Choose Phantom Address in Register depending on v6 support.
 	registration, err := registrationMethod.Register(cjSession, ctx)
@@ -194,7 +194,8 @@ func MakeConjureSession(covert string, transport pb.TransportType) *ConjureSessi
 func FindConjureSessionInRange(covert string, transport pb.TransportType, phantomSubnet *net.IPNet) *ConjureSession {
 
 	count := 0
-	for {
+	Logger().Debugf("Searching for a seed for phatom subnet %v...", phantomSubnet)
+	for count < 100000 {
 		// Generate a random session
 		cjSession := MakeConjureSessionSilent(covert, transport)
 		count += 1
@@ -214,6 +215,8 @@ func FindConjureSessionInRange(covert string, transport pb.TransportType, phanto
 			return cjSession
 		}
 	}
+	Logger().Warnf("Failed to find a session in %v", phantomSubnet)
+	return nil
 }
 
 // IDString - Get the ID string for the session

--- a/tapdance/dialer.go
+++ b/tapdance/dialer.go
@@ -105,6 +105,9 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 					return nil, errors.New("Invalid Phantom network goal")
 				}
 				cjSession = FindConjureSessionInRange(address, d.Transport, phantomRange)
+				if cjSession == nil {
+					return nil, errors.New("Failed to find Phantom in target subnet")
+				}
 			} else {
 				cjSession = MakeConjureSession(address, d.Transport)
 			}

--- a/tapdance/dialer.go
+++ b/tapdance/dialer.go
@@ -91,11 +91,12 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 			flow.tdRaw.useProxyHeader = d.UseProxyHeader
 			return flow, flow.DialContext(ctx)
 		} else {
+			// Conjure
 			// _, err := makeTdFlow(flowBidirectional, nil, address)
 			// if err != nil {
 			// 	return nil, err
 			// }
-			cjSession := MakeConjureSession(address, d.Transport)
+			var cjSession *ConjureSession
 
 			// If specified, only select a phantom from a given range
 			if d.PhantomNet != "" {
@@ -104,6 +105,8 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 					return nil, errors.New("Invalid Phantom network goal")
 				}
 				cjSession = FindConjureSessionInRange(address, d.Transport, phantomRange)
+			} else {
+				cjSession = MakeConjureSession(address, d.Transport)
 			}
 
 			cjSession.TcpDialer = d.TcpDialer

--- a/tapdance/phantoms/phantoms.go
+++ b/tapdance/phantoms/phantoms.go
@@ -281,3 +281,9 @@ func GetDefaultPhantomSubnets() *pb.PhantomSubnetsList {
 		},
 	}
 }
+
+// Just returns the list of subnets provided by the protobuf.
+// Convenience function to not have to export getSubnets() or parseSubnets()
+func GetUnweightedSubnetList(subnetsList *pb.PhantomSubnetsList) ([]*net.IPNet, error) {
+	return parseSubnets(getSubnets(subnetsList, nil, false))
+}


### PR DESCRIPTION
`./cli -connect-addr=1.1.1.1 -registrar bdapi -phantom 192.122.190.0/24`

The way we accomplish this is by repeatedly creating sessions until we get one that lands in the provided subnet.

Note this doesn't override ClientConf: we still use the provided one (and check at startup if the provided range overlaps with at least one subnet), we just keep generating sessions (up to 100k right now, could expand, but that takes about 45s to search) until we find a seed that generates a phantom in our desired subnet.

This PR also fixes a minor bug where conjure overrides the cli-provided `-disable-ipv6` flag. This is fixed now, in case we want to only select v4 phantom (future TODO: figure out a way to let cli provide a v6-only phantom)