### PR TITLE
Fix phantom selection algorithm

### DIFF
--- a/tapdance/conjure.go
+++ b/tapdance/conjure.go
@@ -32,9 +32,12 @@ import (
 // When adding new client versions comment out older versions and add new
 // version below with a description of the reason for the new version.
 func currentClientLibraryVersion() uint32 {
+	// Selection algorithm update - Oct 27, 2022
+	return 2
+
 	// Initial inclusion of client version - added due to update in phantom
 	// selection algorithm that is not backwards compatible to older clients.
-	return 1
+	//return 1
 
 	// // No client version indicates any client before this change.
 	// return 0

--- a/tapdance/phantoms/phantoms_test.go
+++ b/tapdance/phantoms/phantoms_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestIPSelectionBasic(t *testing.T) {
-
 	seed, err := hex.DecodeString("5a87133b68da3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f")
 	require.Nil(t, err)
 
@@ -25,7 +24,8 @@ func TestIPSelectionBasic(t *testing.T) {
 
 	addr, err := SelectAddrFromSubnet(seed, net1)
 	require.Nil(t, err)
-	require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", addr.String())
+	//require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", addr.String())
+	require.Equal(t, "2001:48a8:687f:1:38a3:5a97:50bf:3de5", addr.String())
 }
 
 func TestSelectWeightedMany(t *testing.T) {
@@ -121,15 +121,18 @@ func TestSelectFilter(t *testing.T) {
 
 	p, err := SelectPhantomWeighted([]byte(seed), phantomSubnets, V4Only)
 	require.Nil(t, err)
-	require.Equal(t, "192.122.190.130", p.String())
+	//require.Equal(t, "192.122.190.130", p.String())
+	require.Equal(t, "192.122.190.142", p.String())
 
 	p, err = SelectPhantomWeighted([]byte(seed), phantomSubnets, V6Only)
 	require.Nil(t, err)
-	require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", p.String())
+	//require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", p.String())
+	require.Equal(t, "2001:48a8:687f:1:8e14:49ff:be0d:468d", p.String())
 
 	p, err = SelectPhantomWeighted([]byte(seed), phantomSubnets, nil)
 	require.Nil(t, err)
-	require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", p.String())
+	//require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", p.String())
+	require.Equal(t, "2001:48a8:687f:1:8e14:49ff:be0d:468d", p.String())
 }
 
 func TestPhantomsV6OnlyFilter(t *testing.T) {

--- a/tapdance/phantoms/phantoms_test.go
+++ b/tapdance/phantoms/phantoms_test.go
@@ -205,7 +205,6 @@ func TestForDuplicates(t *testing.T) {
 
 	var ps = &pb.PhantomSubnetsList{
 		WeightedSubnets: []*pb.PhantomSubnets{
-			//{Weight: &w1, Subnets: []string{"192.122.190.0/24"}},
 			{Weight: &w1, Subnets: []string{"2001:48a8:687f:1::/64"}},
 			{Weight: &w9, Subnets: []string{"2002::/64"}},
 		},

--- a/tapdance/phantoms/phantoms_test.go
+++ b/tapdance/phantoms/phantoms_test.go
@@ -250,6 +250,7 @@ func TestForDuplicates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to select adddress: %v -- %s, %v, %v, %v -- %v", err, hex.EncodeToString(curSeed), ps, "None", true, i)
 		}
+		//fmt.Printf("%s %v\n", hex.EncodeToString(curSeed), addr)
 
 		if prev_i, ok := ipSet[addr.String()]; ok {
 			prevSeed := ExpandSeed(seed, salt, prev_i)

--- a/tapdance/phantoms/phantoms_test.go
+++ b/tapdance/phantoms/phantoms_test.go
@@ -149,7 +149,6 @@ func TestSelectFilter(t *testing.T) {
 	p, err = SelectPhantomWeighted([]byte(seed), phantomSubnets, V6Only)
 	require.Nil(t, err)
 	//require.Equal(t, "2001:48a8:687f:1:5fa4:c34c:434e:ddd", p.String())
-	//require.Equal(t, "2001:48a8:687f:1:d8f4:45cd:3ae:fcd4", p.String())
 	require.Equal(t, "2001:48a8:687f:1:5da6:63e0:48a4:b3e", p.String())
 
 	p, err = SelectPhantomWeighted([]byte(seed), phantomSubnets, nil)


### PR DESCRIPTION
**Problem**
Our current (V1) phantom selection algorithm depends on `math/rand` and has a bug involving Varints: we attempt to parse the 256-bit secret as a Varint to get a 4-byte integer, which we seed `math/rand` with. Unfortunately, half of the secrets we would pass in would have a leading 0 bit, causing the Varint parsing to return only the single byte (in the range -64 to 63). As a result, half the time we will only select from a set of 128 phantom IPs.

**Solution**
Client version >= 2 switches to using an HKDF-based version, instead of `math/rand`. This changes the phantom selection algorithm in a breaking way, and so the station uses the provided clientLibVersion to determine whether to use the new HKDF selection or the legacy one(s).

This PR should only be merged after the corresponding station PR (https://github.com/refraction-networking/conjure/pull/145) is merged and deployed on stations.