### PR TITLE
Support custom http client for API registrar

### DIFF
--- a/pkg/registration/api-registrar.go
+++ b/pkg/registration/api-registrar.go
@@ -60,6 +60,7 @@ func NewAPIRegistrar(config *Config) (*APIRegistrar, error) {
 		connectionDelay:    config.Delay,
 		maxRetries:         config.MaxRetries,
 		secondaryRegistrar: config.SecondaryRegistrar,
+		client:             &config.HTTPClient,
 		logger:             tapdance.Logger().WithField("registrar", "API"),
 	}, nil
 }

--- a/pkg/registration/config.go
+++ b/pkg/registration/config.go
@@ -2,6 +2,7 @@ package registration
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/refraction-networking/gotapdance/tapdance"
@@ -37,6 +38,9 @@ type Config struct {
 
 	// SecondaryRegistrar is the secondary registrar to use when the main one fails
 	SecondaryRegistrar tapdance.Registrar
+
+	// HTTPClient is the HTTP client to use for the API registrar
+	HTTPClient http.Client
 }
 
 // DNSTransportMethodType declares the DNS transport method to be used


### PR DESCRIPTION
Add a HTTPClient field in `registration.Config` to be used in API registrar. 

Closes #113