### PR TITLE
Phantom bias command tool

### DIFF
--- a/tapdance/phantoms/phantoms.go
+++ b/tapdance/phantoms/phantoms.go
@@ -19,8 +19,9 @@ type Choice struct {
 }
 
 // getSubnets - return EITHER all subnet strings as one composite array if we are
-//		selecting unweighted, or return the array associated with the (seed) selected
-//		array of subnet strings based on the associated weights
+//
+//	selecting unweighted, or return the array associated with the (seed) selected
+//	array of subnet strings based on the associated weights
 func getSubnets(sc *pb.PhantomSubnetsList, seed []byte, weighted bool) []string {
 
 	var out []string = []string{}
@@ -85,9 +86,11 @@ func getSubnets(sc *pb.PhantomSubnetsList, seed []byte, weighted bool) []string 
 }
 
 // SubnetFilter - Filter IP subnets based on whatever to prevent specific subnets from
-//		inclusion in choice. See v4Only and v6Only for reference.
+//
+//	inclusion in choice. See v4Only and v6Only for reference.
 type SubnetFilter func([]*net.IPNet) ([]*net.IPNet, error)
 
+// V4Only - a functor for transforming the subnet list to only include IPv4 subnets
 func V4Only(obj []*net.IPNet) ([]*net.IPNet, error) {
 	var out []*net.IPNet = []*net.IPNet{}
 

--- a/tools/gen-bias/README.md
+++ b/tools/gen-bias/README.md
@@ -1,0 +1,5 @@
+
+# Conjure ClientConf Bias Generator
+
+This tool takes a conjure client configuration and generates (based on sample selections) the
+popularity of addresses in the phantom subnets.

--- a/tools/gen-bias/main.go
+++ b/tools/gen-bias/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/refraction-networking/gotapdance/protobuf"
+	"github.com/refraction-networking/gotapdance/tapdance/phantoms"
+	"golang.org/x/crypto/hkdf"
+)
+
+func main() {
+	defaultSeed := "5a87133b68ea3468988a21659a12ed2ece07345c8c1a5b08459ffdea4218d12f"
+	defaultSalt := "phantom-bias-test"
+	defaultConfigPath := "../assets/ClientConf"
+	defaultOutFile := "./bias.out"
+
+	var seedStr, saltStr, inFile, outFile string
+	var v6, both bool
+
+	flag.StringVar(&seedStr, "seed", defaultSeed, "Overrides the default seed for phantom selection")
+	flag.StringVar(&saltStr, "salt", defaultSalt, "Overrides the default salt for phantom selection")
+	flag.StringVar(&inFile, "f", defaultConfigPath, "Filepath to look for the parse-able conjure ClientConfig")
+	flag.StringVar(&outFile, "o", defaultOutFile, "Filepath to write output bias into")
+	flag.BoolVar(&v6, "v6", false, "Generate bias output for IPv6 subnets only")
+	flag.BoolVar(&both, "both", false, "Generate bias output for BOTH IPv4 and IPv6 subnets")
+
+	flag.Parse()
+
+	seed, err := hex.DecodeString(seedStr)
+	if err != nil {
+		panic(err)
+	}
+
+	salt := []byte(saltStr)
+
+	clientConf, err := parseClientConf(inFile)
+	if err != nil {
+		panic(err)
+	}
+
+	ps := clientConf.GetPhantomSubnetsList()
+	ipCount := map[string]int{}
+
+	transform := phantoms.V4Only
+	if v6 {
+		transform = phantoms.V6Only
+	} else if both {
+		transform = nil
+	}
+
+	//snets, err := parseSubnets(getSubnets(ps, nil, true))
+	//require.Nil(t, err)
+	//for snet := range snets {
+	//}
+	totTrials := 1_000_000
+	for i := 0; i < totTrials; i++ {
+		curSeed := expandSeed(seed, salt, i)
+		addr, err := phantoms.SelectPhantom(curSeed, ps, transform, true)
+		//addr, err := SelectPhantom(curSeed, ps, nil, true)
+		if err != nil {
+			continue
+		}
+		//require.Nil(t, err)
+		ipCount[addr.String()]++
+	}
+	// Write file
+	f, err := os.Create(outFile)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	for ip, count := range ipCount {
+		f.WriteString(fmt.Sprintf("%s %d\n", ip, count))
+	}
+}
+
+func expandSeed(seed, salt []byte, i int) []byte {
+	bi := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bi, uint64(i))
+	return hkdf.Extract(sha256.New, seed, append(salt, bi...))
+}
+
+func parseClientConf(fname string) (*pb.ClientConf, error) {
+
+	clientConf := &pb.ClientConf{}
+	buf, err := ioutil.ReadFile(fname)
+	if err != nil {
+		return nil, err
+	}
+	err = proto.Unmarshal(buf, clientConf)
+	if err != nil {
+		return nil, err
+	}
+	return clientConf, nil
+}

--- a/tools/makefile
+++ b/tools/makefile
@@ -3,7 +3,7 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
-BINARY_NAMES=clientconf v6lookup elligator-test utls-test # cjprobe
+BINARY_NAMES=clientconf v6lookup elligator-test utls-test gen-bias # cjprobe
 
 
 all: build
@@ -18,6 +18,12 @@ build:
 clientconf:
 	echo "building clientconf"; \
 	cd clientconf && $(GOBUILD) -o ../bin/clientconf ; \
+	cd ../; \
+
+
+gen-bias:
+	echo "building gen-bias"; \
+	cd gen-bias && $(GOBUILD) -o ../bin/gen-bias ; \
 	cd ../; \
 
 v6lookup:


### PR DESCRIPTION
turn the phantom bias test into a golang cmd tool that we can use to generate the expected distribution of selected phantom addresses. 