### PR TITLE
Prefix changes for cli

### DIFF
--- a/pkg/dns-registrar/encryption/encryption.go
+++ b/pkg/dns-registrar/encryption/encryption.go
@@ -2,6 +2,7 @@ package encryption
 
 import (
 	"bufio"
+	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -71,6 +72,10 @@ func GeneratePrivkey() ([]byte, error) {
 
 // PubkeyFromPrivkey returns the public key that corresponds to privkey.
 func PubkeyFromPrivkey(privkey []byte) []byte {
+	if len(privkey) == ed25519.PrivateKeySize {
+		return privkey[ed25519.PublicKeySize:]
+	}
+
 	pubkey, err := curve25519.X25519(privkey, curve25519.Basepoint)
 	if err != nil {
 		panic(err)

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -22,14 +22,14 @@ type Transport interface {
 
 	// GetParams returns a generic protobuf with any parameters from both the registration and the
 	// transport.
-	GetParams() proto.Message
+	GetParams() (proto.Message, error)
 
 	// SetParams allows the caller to set parameters associated with the transport, returning an
 	// error if the provided generic message is not compatible.
 	SetParams(any) error
 
 	// GetDstPort returns the destination port that the client should open the phantom connection with.
-	GetDstPort(seed []byte, params any) (uint16, error)
+	GetDstPort(seed []byte) (uint16, error)
 
 	// PrepareKeys provides an opportunity for the transport to integrate the station public key
 	// as well as bytes from the deterministic random generator associated with the registration

--- a/pkg/transports/transports_test.go
+++ b/pkg/transports/transports_test.go
@@ -23,25 +23,27 @@ func TestTransportParameterFunctionality(t *testing.T) {
 	transport := &min.ClientTransport{}
 
 	// If params is unset it returns nil
-	params := transport.GetParams()
+	params, err := transport.GetParams()
+	require.Nil(t, err)
 	require.Nil(t, params)
 
 	transport.Parameters = paramsRandomize
 
 	// Once params are set it returns a protobuf message that can be cast and parsed or otherwise
 	// operated upon
-	params = transport.GetParams()
+	params, err = transport.GetParams()
+	require.Nil(t, err)
 	require.Equal(t, true, params.(*pb.GenericTransportParams).GetRandomizeDstPort())
 
 	// We can then set the parameters if the proper parameters structure is provided even using
 	// the generic transport interface.
 	var gt cj.Transport = transport
-	err := gt.SetParams(paramsStatic)
+	err = gt.SetParams(paramsStatic)
 	require.Nil(t, err)
 
 	// The updated parameters are reflected when we get the parameters,  again returning a protobuf
 	// message that can be cast and parsed or otherwise operated upon.
-	params = transport.GetParams()
+	params, err = transport.GetParams()
 	require.Nil(t, err)
 	require.Equal(t, false, params.(*pb.GenericTransportParams).GetRandomizeDstPort())
 

--- a/tapdance/conjure.go
+++ b/tapdance/conjure.go
@@ -77,7 +77,7 @@ func DialConjure(ctx context.Context, cjSession *ConjureSession, registrationMet
 		return nil, err
 	}
 
-	Logger().Debugf("%v Attempting to Connect ...", cjSession.IDString())
+	Logger().Debugf("%v Attempting to Connect using %s ...", cjSession.IDString(), registration.Transport.Name())
 	return registration.Connect(ctx)
 }
 
@@ -276,7 +276,7 @@ func (cjSession *ConjureSession) UnidirectionalRegData(regSource *pb.Registratio
 
 	reg.phantom4 = phantom4
 	reg.phantom6 = phantom6
-	reg.phantomDstPort, err = cjSession.Transport.GetDstPort(reg.keys.ConjureSeed, nil)
+	reg.phantomDstPort, err = cjSession.Transport.GetDstPort(reg.keys.ConjureSeed)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -642,7 +642,13 @@ func (reg *ConjureReg) getPbTransport() pb.TransportType {
 }
 
 func (reg *ConjureReg) getPbTransportParams() (*anypb.Any, error) {
-	var m proto.Message = reg.Transport.GetParams()
+	var m proto.Message
+	m, err := reg.Transport.GetParams()
+	if err != nil {
+		return nil, err
+	} else if m == nil {
+		return nil, nil
+	}
 	return anypb.New(m)
 }
 


### PR DESCRIPTION
This is a follow-on to #121 that cleans up several things that were missed, like

* Prefix compatibility with `transports.NewWithParams()`
* Client option to use a random prefix


 https://github.com/refraction-networking/conjure/pull/165 
 https://github.com/refraction-networking/conjure/pull/183
