### PR TITLE
Move toward using conjure-provided assets

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -90,7 +90,7 @@ func main() {
 	// Check that the provided phantom net overlaps with at least one of our phatom options
 	if *phantomNet != "" {
 		// Load phantoms
-		subnets, err := phantoms.GetUnweightedSubnetList(tapdance.Assets().GetPhantomSubnets())
+		subnets, err := phantoms.GetUnweightedSubnetList(ca.Assets().GetPhantomSubnets())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to get Phantom subnets: %v\n", err)
 			os.Exit(255)
@@ -253,14 +253,14 @@ func manageConn(tdDialer tapdance.Dialer, connectTarget string, clientConn *net.
 
 	p, err := tdDialer.TransportConfig.GetParams()
 	if err != nil {
-		fmt.Printf("failed to get transport params: %v\n", err)
+		tapdance.Logger().Errorf("failed to get transport params: %v\n", err)
 		return
 	}
-	fmt.Printf("transport: %s - %s - gen-%d\n", tdDialer.TransportConfig.String(), p, tapdance.Assets().GetGeneration())
+	tapdance.Logger().Debugf("transport: %s - %s - gen-%d\n", tdDialer.TransportConfig.String(), p, ca.Assets().GetGeneration())
 
 	tdConn, err := tdDialer.Dial("tcp", connectTarget)
 	if err != nil || tdConn == nil {
-		fmt.Printf("failed to dial %s: %v\n", connectTarget, err)
+		tapdance.Logger().Errorf("failed to dial %s: %v\n", connectTarget, err)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0
-	github.com/refraction-networking/conjure v0.7.6
+	github.com/refraction-networking/conjure v0.7.7
 	github.com/refraction-networking/ed25519 v0.1.2
 	github.com/refraction-networking/utls v1.3.3
 	github.com/sergeyfrolov/bsbuffer v0.0.0-20180903213811-94e85abb8507
@@ -26,7 +26,6 @@ require (
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/gaukas/godicttls v0.0.4 // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
 	github.com/keltia/proxy v0.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/gaukas/godicttls v0.0.4 h1:NlRaXb3J6hAnTmWdsEKb9bcSBD6BvcIjdGdeb0zfXb
 github.com/gaukas/godicttls v0.0.4/go.mod h1:l6EenT4TLWgTdwslVb4sEMOCf7Bv0JAK67deKr9/NCI=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -77,8 +75,8 @@ github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
 github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/refraction-networking/conjure v0.7.6 h1:cNTLrhFXTLGJaL3J6iiSncGDRAYzXbX7MGSvVlxn/Wk=
-github.com/refraction-networking/conjure v0.7.6/go.mod h1:/UxAcot49ii6ejyvBrSo3g10yyUEavaGJT1Iy47oAfU=
+github.com/refraction-networking/conjure v0.7.7 h1:8vWFmSzmkNSrVr1TI4BRbgCD1tc3FTIm40PzjI2olRQ=
+github.com/refraction-networking/conjure v0.7.7/go.mod h1:/UxAcot49ii6ejyvBrSo3g10yyUEavaGJT1Iy47oAfU=
 github.com/refraction-networking/ed25519 v0.1.2 h1:08kJZUkAlY7a7cZGosl1teGytV+QEoNxPO7NnRvAB+g=
 github.com/refraction-networking/ed25519 v0.1.2/go.mod h1:nxYLUAYt/hmNpAh64PNSQ/tQ9gTIB89wCaGKJlRtZ9I=
 github.com/refraction-networking/obfs4 v0.1.2 h1:J842O4fGSkd2W8ogYj0KN6gqVVY+Cpqodw9qFGL7wVU=
@@ -155,7 +153,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/grpc v1.58.0 h1:32JY8YpPMSR45K+c3o6b8VL73V+rR8k+DeMIr4vRH8o=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tapdance/assets-phantoms_test.go
+++ b/tapdance/assets-phantoms_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAssetsPhantomsBasics(t *testing.T) {
-	phantomSet := Assets().GetPhantomSubnets()
+	phantomSet := ca.Assets().GetPhantomSubnets()
 	assert.NotNil(t, phantomSet)
 }
 
@@ -29,13 +29,13 @@ func TestAssetsPhantoms(t *testing.T) {
 			// fmt.Printf("TapDance log was:\n%s\n", b.String())
 		}
 	}()
-	oldpath := Assets().path
+	oldpath := ca.Assets().GetAssetsDir()
 
 	dir1 := t.TempDir()
 
 	var testPhantoms = ps.GetDefaultPhantomSubnets()
 
-	AssetsSetDir(dir1)
+	ca.AssetsSetDir(dir1)
 	err := ca.Assets().SetPhantomSubnets(testPhantoms)
 	if err != nil {
 		t.Fatal(err)

--- a/tapdance/assets-phantoms_test.go
+++ b/tapdance/assets-phantoms_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	ps "github.com/refraction-networking/conjure/pkg/phantoms"
+	ca "github.com/refraction-networking/conjure/pkg/client/assets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func TestAssetsPhantoms(t *testing.T) {
 	var testPhantoms = ps.GetDefaultPhantomSubnets()
 
 	AssetsSetDir(dir1)
-	err := Assets().SetPhantomSubnets(testPhantoms)
+	err := ca.Assets().SetPhantomSubnets(testPhantoms)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,5 +59,5 @@ func TestAssetsPhantoms(t *testing.T) {
 	require.Equal(t, "192.122.190.178", addr4.String())
 	require.Nil(t, addr6)
 
-	AssetsSetDir(oldpath)
+	ca.AssetsSetDir(oldpath)
 }

--- a/tapdance/assets.go
+++ b/tapdance/assets.go
@@ -39,6 +39,11 @@ var assetsOnce sync.Once
 // First access to singleton sets path. Assets(), if called
 // before SetAssetsDir() sets path to "./assets/"
 func Assets() *assets {
+	// We leave this warning here, because only Tapdance should
+	// use this instance. Conjure uses assets provided by
+	// github.com/refraction-networking/conjure/pkg/client/assets
+	// and this Assets (and Tapdance as a whole) is deprecated
+	Logger().Warnf("Loading TapDance Assets...")
 	var err error
 	_initAssets := func() { err = initAssets("./assets/") }
 	assetsOnce.Do(_initAssets)

--- a/tapdance/assets.go
+++ b/tapdance/assets.go
@@ -43,7 +43,7 @@ func Assets() *assets {
 	// use this instance. Conjure uses assets provided by
 	// github.com/refraction-networking/conjure/pkg/client/assets
 	// and this Assets (and Tapdance as a whole) is deprecated
-	Logger().Warnf("Loading TapDance Assets...")
+	Logger().Warnf("Loading TapDance Assets...(deprecated; use conjure assets)")
 	var err error
 	_initAssets := func() { err = initAssets("./assets/") }
 	assetsOnce.Do(_initAssets)

--- a/tapdance/conjure.go
+++ b/tapdance/conjure.go
@@ -15,6 +15,7 @@ import (
 	"github.com/refraction-networking/conjure/pkg/core/interfaces"
 	ps "github.com/refraction-networking/conjure/pkg/phantoms"
 	pb "github.com/refraction-networking/conjure/proto"
+	ca "github.com/refraction-networking/conjure/pkg/client/assets"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -58,6 +59,7 @@ func DialConjure(ctx context.Context, cjSession *ConjureSession, registrationMet
 	// Prepare registrar specific keys
 	registrationMethod.PrepareRegKeys(getStationKey(), cjSession.Keys.SharedSecret)
 	// Choose Phantom Address in Register depending on v6 support.
+
 	registration, err := registrationMethod.Register(cjSession, ctx)
 	if err != nil {
 		Logger().Debugf("%v Failed to register: %v", cjSession.IDString(), err)
@@ -519,12 +521,12 @@ func (reg *ConjureReg) UnpackRegResp(regResp *pb.RegistrationResponse) error {
 
 	// Client config -- check if not nil in the registration response
 	if regResp.GetClientConf() != nil {
-		currGen := Assets().GetGeneration()
+		currGen := ca.Assets().GetGeneration()
 		incomingGen := regResp.GetClientConf().GetGeneration()
 		Logger().Debugf("received clientconf in regResponse w/ gen %d", incomingGen)
 		if currGen < incomingGen {
 			Logger().Debugf("Updating clientconf %d -> %d", currGen, incomingGen)
-			_err := Assets().SetClientConf(regResp.GetClientConf())
+			_err := ca.Assets().SetClientConf(regResp.GetClientConf())
 			if _err != nil {
 				Logger().Warnf("could not set ClientConf in bidirectional API: %v", _err.Error())
 			}
@@ -577,7 +579,7 @@ func (reg *ConjureReg) generateClientToStation(ctx context.Context) (*pb.ClientT
 
 	//[reference] Generate ClientToStation protobuf
 	// transition := pb.C2S_Transition_C2S_SESSION_INIT
-	currentGen := Assets().GetGeneration()
+	currentGen := ca.Assets().GetGeneration()
 	currentLibVer := core.CurrentClientLibraryVersion()
 	transport := reg.getPbTransport()
 
@@ -682,7 +684,7 @@ func sleepWithContext(ctx context.Context, duration time.Duration) {
 
 // SelectPhantom - select one phantom IP address based on shared secret
 func SelectPhantom(seed []byte, support uint) (*net.IP, *net.IP, bool, error) {
-	phantomSubnets := Assets().GetPhantomSubnets()
+	phantomSubnets := ca.Assets().GetPhantomSubnets()
 	switch support {
 	case v4:
 		phantomIPv4, err := ps.SelectPhantom(seed, phantomSubnets, ps.V4Only, true)
@@ -712,7 +714,7 @@ func SelectPhantom(seed []byte, support uint) (*net.IP, *net.IP, bool, error) {
 }
 
 func getStationKey() [32]byte {
-	return *Assets().GetConjurePubkey()
+	return *ca.Assets().GetConjurePubkey()
 }
 
 // GetRandomDuration returns a random duration that

--- a/tapdance/conjure_test.go
+++ b/tapdance/conjure_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/refraction-networking/conjure/pkg/core"
 	pb "github.com/refraction-networking/conjure/proto"
 	tls "github.com/refraction-networking/utls"
+	ps "github.com/refraction-networking/conjure/pkg/phantoms"
+	ca "github.com/refraction-networking/conjure/pkg/client/assets"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,6 +56,20 @@ func TestSelectBoth(t *testing.T) {
 	seed := []byte{
 		0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
 		0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF,
+	}
+
+	// Set up temp directory for stub ClientConf (so we don't overwrite our current one)
+	oldpath := ca.Assets().GetAssetsDir()
+	ca.AssetsSetDir(t.TempDir())
+	defer ca.AssetsSetDir(oldpath)
+
+	// Default Phantoms (can't assume ClientConf is particular dev version)
+	var testPhantoms = ps.GetDefaultPhantomSubnets()
+
+	// Set phantoms
+	err := ca.Assets().SetPhantomSubnets(testPhantoms)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	phantomIPAddr4, phantomIPAddr6, _, err := SelectPhantom(seed, both)
@@ -126,8 +142,8 @@ func TestRegDigest(t *testing.T) {
 }
 
 func TestCheckV6Decoys(t *testing.T) {
-	AssetsSetDir("./assets")
-	decoysV6 := Assets().GetV6Decoys()
+	ca.AssetsSetDir("./assets")
+	decoysV6 := ca.Assets().GetV6Decoys()
 	numDecoys := len(decoysV6)
 
 	for _, decoy := range decoysV6 {


### PR DESCRIPTION
Currently, we have assets.go both in the conjure and gotapdance (this) repositories. While both are singletons, they do not share the same instance, so it is possible for a client to have both a conjure.Assets() and a gotapdance.Assets() singletons as separate instances.

This PR moves all conjure-based use of Assets to use the conjure assets (`github.com/refraction-networking/conjure/pkg/client/assets`). There is a corresponding PR for the conjure side to fix additional circular uses of gotapdance.Assets() from there: https://github.com/refraction-networking/conjure/pull/247

The conjure PR should be merged first for this one to work. To test this prior to the above being merged, you can build your client with the conjure branch by doing `go get github.com/refraction-networking/conjure/pkg/client/assets@use-conjure-assets` in your gotapdance repository and rebuilding the cli.

Note that this PR still leaves assets.go in the gotapdance repository, because the tapdance code still uses these assets. We could switch (and remove assets.go entirely from gotapdance) but given that Tapdance is deprecated and we cannot test it, I'm leaving it for now, with a warn message in case someone tries to use the (now tapdance-only) assets in this repository.