### PR TITLE
Feature for appending toml

### DIFF
--- a/tools/clientconf/1169
+++ b/tools/clientconf/1169
@@ -1,7850 +1,0 @@
-
-éﬁ
-
-epibio.msu.edu|#
-
-httpd.sip.msu.eduw#
-
-www.law.msu.eduŒ#
-
-aris.rad.msu.edu»†#
-
-glccn.iwr.msu.edupy#
-
-pathobiology.msu.edu¯–#
-
-svn.cvm.msu.edu∑–#
-
-tic9.lib.msu.eduﬂ#
-+
-$officeonline01.intranet.nscl.msu.edu2 #
-
-stash.frib.msu.edu`!#
-
-locate.lib.msu.eduﬂ#
-
-radzfp01.rad.msu.edu»ü#
-
-pro2.educ.msu.eduà©#
-
-maps.gmsts.org #
-
-websvcs.lib.msu.eduﬂ#
-
-www.misin.msu.edu #
-
-enterprise.frib.msu.edu`!#
-+
-$officeonline02.intranet.nscl.msu.edu2 #
-
-gsrpdf.lib.msu.eduﬂ#
-
-afrjpdf.lib.msu.eduﬂ#
-
-maps.asets.msu.edu #
-
-copycenter.educ.msu.eduà©#
-
-www.dcpah.msu.edu¯–#
-
-envlit.educ.msu.eduà©#
-
-glccn.iwr.msu.eduoy#
-&
-enterprise-worker4.nscl.msu.edu"#
-
-mmm.lib.msu.eduCﬂ#
-
-library.msu.eduTﬂ#
-
-www.loncapa.msu.eduÈd#
-
-tribuneentry.lib.msu.eduﬂ#
-
-smgr1.sip.msu.eduw#
-
-www.hub.msu.eduKﬂ#
-
-lhfacility.msu.edu#
-
-gateway.frib.msu.edu`!#
-
-wjxg.lib.msu.eduKﬂ#
-
-help.nscl.msu.eduî##
-(
-!xenapp-sf01.intranet.nscl.msu.eduv #
-
-publicapps.nscl.msu.edu® #
-
-slikerentry.lib.msu.eduﬂ#
-
-www.asets.msu.edu #
-
-tic.lib.msu.eduTﬂ#
-
-orlab.educ.msu.eduà©#
-
-login.lib.msu.eduTﬂ#
-
-dpps.msu.edu#
-
-smgr2.sip.msu.eduw#
-
-sip.msu.edux#
-
-pdfproc.lib.msu.eduﬂ#
-
-agbib.lib.msu.edu>ﬂ#
-
-www.epicedpolicy.msu.eduà©#
-
-publicapps.frib.msu.edu® #
-
-gateway01.frib.msu.edu`!#
-
-userportal.frib.msu.edu`!#
-
-gateway01.nscl.msu.edu`!#
-
-grassius.org…ò#
-$
-www.mttc-process.educ.msu.eduà©#
-
-www.new.law.msu.eduŒ#
-
-servu.usd.msu.edu&5#
-
-enviroimpact.iwr.msu.eduoy#
-
-gateway.frib.msu.eduî##
-
-new.law.msu.eduŒ#
-
-smgr2.sip.msu.edux#
-
-radzfp01.rad.msu.edu»ü#
-
-docs.slowthespread.org2 #
-
-smgr1.sip.msu.edux#
-
-enterprise.nscl.msu.eduî##
-
-lib.msu.eduﬂ#
-
-www.orlab.educ.msu.eduà©#
-
-gis.iwr.msu.eduiy#
- 
-officeonline.frib.msu.edu2 #
-
-stash.frib.msu.eduî##
-"
-officeonline01.frib.msu.edu2 #
-
-help.frib.msu.eduî##
- 
-dotnet-ext01.frib.msu.edu® #
-
-www.pathobiology.msu.edu¯–#
-"
-aquaticanimalhealth.msu.edu¯–#
-!
-www.compstrat.educ.msu.eduà©#
-
-usd-svr108.usd.msu.edu&5#
- 
-mttc-process.educ.msu.eduà©#
-
-smgr1.sip.msu.edux#
-
-publicapps.nscl.msu.edu"#
-
-tic.msu.eduTﬂ#
-
-dcpah.msu.edu¯–#
-
-dpps.msu.edu#
-
-servu.usd.msu.edu&5#
-
-loncapa.msu.eduÈd#
-
-enterprise.frib.msu.eduî##
-
-compstrat.educ.msu.eduà©#
-
-s5.lite.msu.eduÌd#
-
-publicapps.frib.msu.edu"#
-
-globalfood.law.msu.eduŒ#
-
-m.lib.msu.eduTﬂ#
-
-www.tic.msu.eduTﬂ#
-
-vss1.loncapa.msu.eduÚd#
-)
-"officeonline.intranet.nscl.msu.edu2 #
-
-accounts.frib.msu.eduv #
-
-smgr1.sip.msu.eduw#
-
-agris-knowledgebase.org–ò#
-
-wapp.cvm.msu.edu∑–#
-
-www.cvm.msu.edu¯–#
-
-s1.lite.msu.eduÂd#
-
-appscb.frib.msu.eduv #
-
-zendesk.police.msu.eduY#
-
-fuzzy.asets.msu.edu	 #
-
-www.envlit.educ.msu.eduà©#
-
-httpd.sip.msu.edux#
-
-sip.msu.eduw#
-
-metadata.lib.msu.edu)ﬂ#
-
-animalhealth.msu.edu¯–#
-
-sip.msu.edux#
-
-wbh12.geo.msu.eduD#
-
-xenapp-sf02.frib.msu.eduv #
-
-apps.frib.msu.eduv #
-
-httpd.sip.msu.edux#
-
-vethospital.cvm.msu.edu¯–#
-!
-www.journalofexpertise.org>0#
-!
-digitalcommons.law.msu.eduŒ#
-
-httpd.sip.msu.eduw#
-
-lon-capa.msu.eduÈd#
-
-userportal.frib.msu.eduî##
-
-xenapp-sf01.frib.msu.eduv #
-
-interlib.lib.msu.eduﬂ#
-
-apps.nscl.msu.eduv #
-
-aclgoals.educ.msu.eduà©#
-
-smgr2.sip.msu.edux#
-"
-www.vethospital.cvm.msu.edu¯–#
-
-swamplr.lib.msu.edu]ﬂ#
- 
-dotnet-ext02.frib.msu.edu® #
-
-avida-ed.msu.edu†§#
-"
-officeonline02.frib.msu.edu2 #
-&
-www.aquaticanimalhealth.msu.edu¯–#
-
-teachingcenter.msu.eduKﬂ#
-
-d.lib.msu.edu]ﬂ#
-
-lib.msu.eduTﬂ#
-
-gds.lib.msu.edu’ﬂ#
-"
-www.copycenter.educ.msu.eduà©#
-
-gateway01.nscl.msu.eduî##
-&
-enterprise-worker4.frib.msu.edu"#
-
-www.lon-capa.msu.eduÈd#
-
-s2.lite.msu.eduÊd#
-#
-blast.grassius.eglab-dev.com ò#
-
-gis2.iwr.msu.eduèy#
-
-parking.msu.edu#
-
-gateway01.frib.msu.eduî##
-
-epicedpolicy.msu.eduà©#
-
-blogs.lib.msu.eduTﬂ#
-
-sip.msu.eduw#
-
-help.nscl.msu.edu`!#
-
-lists.psy.msu.edu0#
-
-portal.frib.msu.edu`!#
-
-repo-web.lib.msu.edu]ﬂ#
-
-www.animalhealth.msu.edu¯–#
-)
-"accessibility-intranet.lib.msu.eduÀﬂ#
-
-usd-svr108.usd.msu.edu&5#
-
-mainweb7.lib.msu.eduTﬂ#
-!
-mail.ghalibconcordance.orgh‡#
-
-codeprod.lib.msu.edu#
-
-vmhc.lib.msu.eduÀﬂ#
-
-calendar.cal.msu.edu™‡#
-
-c4i.msu.edu™‡#
-
-illiad3.lib.msu.eduﬂ#
-
-dmhsp.lib.msu.edu]ﬂ#
-
-ctli.lib.msu.eduKﬂ#
-
-wbh02.geo.msu.edu#
-
-testing.elc.msu.edu}‡#
-
-blogpublic.lib.msu.eduTﬂ#
-
-acm.cal.msu.edu™‡#
-
-s7.lite.msu.eduÔd#
-
-toneperfect.lib.msu.edu]ﬂ#
-
-mainweb9.lib.msu.eduﬂ#
- 
-accessibleart.cal.msu.edu™‡#
-
-cofad.cal.msu.edu™‡#
-
-ippsr.msu.eduG#
-
-mail.shtisel-diary.orgh‡#
-
-urires.lib.msu.eduÀﬂ#
-
-mail.clear.msu.eduh‡#
-
-tone.lib.msu.edu]ﬂ#
-
-spc.lib.msu.eduÀﬂ#
-
-ingest.lib.msu.edu]ﬂ#
-
-csapp.cal.msu.edu™‡#
-
-mail.llc.msu.eduh‡#
-
-blast.camregbase.orgŒò#
-!
-mail.ghalibconcordance.orgh‡#
-
-woci.cal.msu.edu™‡#
-
-ticmag.lib.msu.edu]ﬂ#
-
-sentinelws.msu.edu%0	#
-
-cms02.cascade.msu.eduÃ
-	#
-
-tone-legacy.lib.msu.edu]ﬂ#
-
-reservations.lib.msu.eduÀﬂ#
-
-mail.elc.msu.eduh‡#
- 
-education2035.cal.msu.edu™‡#
-
-socialmedia.msu.edu&0	#
-#
-moria-jupyterhub.egr.msu.eduì%	#
-
-ojs.msupress.msu.eduàﬂ#
-
-deans.msu.edu™‡#
-
-gateway.nscl.msu.edu`!#
-
-deansreport.cal.msu.edu™‡#
-
-mail.shtisel-diary.orgh‡#
-
-mail.mi-diaries.orgh‡#
-
-grange.lib.msu.edu]ﬂ#
-
-packstore.lib.msu.eduÀﬂ#
-
-mail.elc.msu.eduh‡#
-
-d-legacy.lib.msu.edu]ﬂ#
-
-mail.mi-diaries.orgh‡#
-(
-!xenapp-sf02.intranet.nscl.msu.eduv #
-
-er.lib.msu.eduÀﬂ#
-
-etd.lib.msu.edu]ﬂ#
-
-ticpass.lib.msu.eduÀﬂ#
-
-mail.camps.cal.msu.eduh‡#
-
-www.lib.msu.eduÀﬂ#
-
-rt.hpcc.msu.eduó	#
-
-muses.cal.msu.edu™‡#
-
-xa.cal.msu.edu™‡#
-
-globalsafety.msu.eduD0	#
-
-webapp.cvm.msu.edu∑–#
-
-mail.celta.msu.eduh‡#
-
-marcom.cal.msu.edu™‡#
-
-mail.sls.msu.eduh‡#
-
-elc.msu.edu™‡#
-
-dock.matrix.msu.edu 	#
-
-cse.msu.edu	#
-
-mail.h-net.org	#
-
-pressojs.lib.msu.eduàﬂ#
-
-globalyouth.isp.msu.eduD0	#
-
-osimis.egr.msu.eduì%	#
-
-foglio.cal.msu.edu™‡#
-
-files.cal.msu.eduM‡#
-
-sepos.cal.msu.edu™‡#
-
-repo.lib.msu.edu]ﬂ#
-
-git.egr.msu.eduõ%	#
-
-oirc.msu.eduD0	#
-
-mail.shtisel-diary.orgh‡#
-
-maflt.cal.msu.edu™‡#
-
-j1scholar.ais.msu.eduD0	#
-
-misc.lib.msu.eduÀﬂ#
-
-ojs-web.msupress.orgàﬂ#
-
-spcrequest.lib.msu.eduèﬂ#
-
-gitlab.matrix.msu.edu 	#
-
-dhlc.cal.msu.edu™‡#
-
-mail.camps.cal.msu.eduh‡#
-
-yagi.h-net.org(	#
-
-kylewhyte.cal.msu.edu™‡#
-
-commdeptreview.msu.edu/0	#
-
-www.events.msu.eduJ0	#
-
-events.msu.eduJ0	#
-
-www.sentinelws.msu.edu%0	#
-
-tcb.lib.msu.edu’ﬂ#
-
-chat.matrix.msu.edu 	#
-
-rindexer.lib.msu.edu]ﬂ#
-
-mail.mi-diaries.orgh‡#
- 
-annualreports.ipf.msu.eduX0	#
-
-web6.cal.msu.edu´‡#
-
-hamilton.h-net.org	#
-
-muse.cal.msu.edu™‡#
-
-mail.clear.msu.eduh‡#
-
-mail.shtisel-diary.orgh‡#
-
-mail.celta.msu.eduh‡#
-%
-slimgpu-jupyterhub.egr.msu.eduì%	#
-
-mail.mi-diaries.orgh‡#
-
-mail.llc.msu.eduh‡#
-
-cats.h-net.orgÙ	#
-
-blazar.egr.msu.edu=%	#
-
-lists.h-net.org	#
-
-michilac.lib.msu.edu]ﬂ#
-#
-docstatus.itservices.msu.edu0	#
-
-rdsvdi-cb1.egr.msu.eduË%	#
-
-mail.clear.msu.eduh‡#
-
-intranet.lib.msu.eduÄﬂ#
-
-web.cal.msu.edu™‡#
-
-www.c4i.msu.edu™‡#
-
-www.egr.msu.edu>%	#
-
-remote.egr.msu.eduË%	#
-
-wide.cal.msu.edu™‡#
-
-mail.llc.msu.eduh‡#
-
-mail.elc.msu.eduh‡#
-
-web5.cal.msu.edu™‡#
-
-comreview.msu.edu00	#
- 
-intranet-prod.lib.msu.eduÄﬂ#
-
-copyright.lib.msu.eduÀﬂ#
-
-cse.msu.edu	#
-
-vetp.isp.msu.eduD0	#
-
-cse.msu.eduŸ	#
-
-yagi.h-net.org(	#
-
-mail.sls.msu.eduh‡#
-
-vipp.isp.msu.eduD0	#
- 
-rdsvdi-webgw2.egr.msu.eduË%	#
-
-egr.msu.edu>%	#
-
-fuse.cal.msu.edu™‡#
-
-rds.egr.msu.eduË%	#
-
-smtp.campusad.msu.edui0	#
-
-mirrors.egr.msu.eduí%	#
-
-www.clacs.isp.msu.eduD0	#
-$
-turing-jupyterhub.egr.msu.eduì%	#
-
-contact.icer.msu.eduá	#
-
-olin.msu.eduK0	#
-
-listings.lib.msu.eduñﬂ#
-
-mail.clear.msu.eduh‡#
-
-globalyouth.msu.eduD0	#
- 
-server-status.lib.msu.eduÀﬂ#
-
-hamilton.h-net.org	#
-
-egr.msu.edu<%	#
-!
-beta.ondemand.hpcc.msu.eduÉ	#
-
-mail.camps.cal.msu.eduh‡#
-
-oihs.isp.msu.eduD0	#
-
-mail.shtisel-diary.orgh‡#
-
-mail.camps.cal.msu.eduh‡#
-
-dossier.lib.msu.edu›ﬂ#
-
-mail.llc.msu.eduh‡#
-
-hybrid.campusad.msu.edui0	#
-
-mail.h-net.org	#
-
-git.lib.msu.eduÀﬂ#
-
-clacs.msu.eduD0	#
-!
-mail.ghalibconcordance.orgh‡#
-
-khalil.cal.msu.edu™‡#
-
-repropedia.comì0	#
-
-mail.celta.msu.eduh‡#
-
-globalsafety.isp.msu.eduD0	#
-
-globalafrica.isp.msu.eduD0	#
-
-www.oihs.msu.eduD0	#
-#
-dev.globalsafety.isp.msu.eduD0	#
-!
-mail.ghalibconcordance.orgh‡#
-
-mail.celta.msu.eduh‡#
-
-mail.mi-diaries.orgh‡#
-
-pscd.msu.eduD0	#
-!
-jupyterhub-gpu.egr.msu.eduì%	#
-
-www.oihs.isp.msu.eduD0	#
-
-broker.egr.msu.eduË%	#
-
-oirc.isp.msu.eduD0	#
-
-jupyterhub.egr.msu.eduì%	#
-
-vpn-rsc.egr.msu.eduÏ$	#
-
-analytics.h-net.orgK	#
-"
-achievements.webapp.msu.edu{0	#
-
-www.globalafrica.msu.eduD0	#
-
-vetp.msu.eduD0	#
-
-vis.itservices.msu.edu20	#
-
-rdsvdi-cb2.egr.msu.eduË%	#
-#
-demo.framework.comms.msu.edux0	#
-
-concussion.msu.eduá0	#
-
-www.clacs.msu.eduD0	#
-
-snapp.rad.msu.eduá0	#
-
-www.comms.msu.edu&0	#
-
-oihs.msu.eduD0	#
-&
-www.tanzaniapartnership.msu.eduD0	#
-
-film.msu.edu™‡#
-
-reprotopia.msu.eduì0	#
-"
-jupyterhub-test.egr.msu.eduì%	#
-
-clacs.isp.msu.eduD0	#
-
-mail.elc.msu.eduh‡#
-#
-cad-ex19-01.campusad.msu.edui0	#
-
-anatomy.msu.eduá0	#
-
-www.egr.msu.edu<%	#
-
-mail.elc.msu.eduh‡#
-#
-cad-ex19-03.campusad.msu.edui0	#
- 
-www.concussionimaging.comá0	#
-
-mail.sls.msu.eduh‡#
-
-oiss.isp.msu.eduD0	#
-"
-religioussounds.cal.msu.edu™‡#
-#
-cad-ex19-02.campusad.msu.edui0	#
-$
-jupyterhub-grader.egr.msu.eduì%	#
-
-dfsca.msu.eduJ0	#
-#
-cad-ex16-01.campusad.msu.edui0	#
-
-education.rad.msu.eduá0	#
-
-tedx.obgyn.msu.eduì0	#
-$
-jupyterhub-legacy.egr.msu.eduì%	#
-
-vipp.msu.eduD0	#
-
-mail.campusad.msu.edui0	#
-
-stage.comms.msu.edux0	#
-+
-$coursecompute-jupyterhub.egr.msu.eduì%	#
-
-www.vipp.isp.msu.eduD0	#
-
-youthempowerment.msu.eduD0	#
-
-www.pscd.isp.msu.eduD0	#
-
-pscd.isp.msu.eduD0	#
-
-globalideas.isp.msu.eduD0	#
-'
- www.youthempowerment.isp.msu.eduD0	#
-#
-cad-ex16-04.campusad.msu.edui0	#
-
-bootcamp.msu.eduJ0	#
-
-riker.egr.msu.eduì%	#
-&
-cerberus-jupyterhub.egr.msu.eduì%	#
-
-qual.mdid.art.msu.edud0	#
-
-econ.msu.edui0	#
-
-www.rad.msu.eduá0	#
-
-www.vetp.msu.eduD0	#
-
-vpn.egr.msu.eduÏ$	#
-
-www.vetp.isp.msu.eduD0	#
-
-public.api.msu.eduR0	#
-
-community.idm.msu.edu*0	#
-#
-cad-ex19-04.campusad.msu.edui0	#
-
-www.pscd.msu.eduD0	#
-#
-www.youthempowerment.msu.eduD0	#
- 
-autodiscover.cabs.msu.edui0	#
-
-autodiscover.msu.edui0	#
-*
-#www.tanzaniapartnership.isp.msu.eduD0	#
-
-matrix.msu.edu#	#
-!
-www.commdeptreview.msu.edu/0	#
-#
-cad-ex16-02.campusad.msu.edui0	#
-
-www.radiology.msu.eduá0	#
- 
-myoiss.itservices.msu.eduN0	#
-$
-savemyfertility.obgyn.msu.eduì0	#
-
-www.woodrufflab.orgì0	#
-
-www.keyring.bric.msu.edu{	#
-
-www.rehab.msu.eduá0	#
-#
-www.globalsafety.isp.msu.eduD0	#
-
-www.bootcamp.msu.eduJ0	#
-#
-cad-ex16-03.campusad.msu.edui0	#
-
-sportsnutrition.msu.eduá0	#
-
-law.msu.edui0	#
-
-www.snapp.msu.eduá0	#
-#
-www.globalafrica.isp.msu.eduD0	#
-!
-hit-filemakerwb.hc.msu.eduE0	#
-"
-ipf-atcsprod.pplant.msu.edur0	#
-
-mls.chm.msu.edu
-	#
-
-www.sass.msu.eduÑ0	#
-
-research.rad.msu.eduá0	#
-
-www.msuhla.chm.msu.edu≥3	#
-
-menopause.obgyn.msu.eduì0	#
-
-wbp.rad.msu.eduá0	#
-
-oncofertility.msu.eduì0	#
-
-fw-ats.bric.msu.edu2{	#
-
-snapp.msu.eduá0	#
-
-rehab.msu.eduá0	#
-
-savemyeggs.orgì0	#
-
-www.socialmedia.msu.edu&0	#
-
-sass.msu.eduÑ0	#
-
-www.oirc.msu.eduD0	#
-
-savemyfertility.orgì0	#
-
-www.oiss.msu.eduD0	#
-
-timesheets.rad.msu.eduá0	#
-
-oiss.msu.eduD0	#
-
-woodrufflab.netì0	#
-
-autodiscover.ath.msu.edui0	#
-
-www.olin.msu.eduK0	#
-
-concussionimaging.comá0	#
-!
-womenshealth.obgyn.msu.eduì0	#
-
-msuoutreach.loncapa.orgîJ	#
-$
-autodiscover.campusad.msu.edui0	#
-
-www.savemyfertility.orgì0	#
-
-mail.msu.edui0	#
-
-www.globalsafety.msu.eduD0	#
-&
-tanzaniapartnership.isp.msu.eduD0	#
- 
-beaumontcam.comms.msu.eduï0	#
-
-ath.msu.edui0	#
-
-www.dfsca.msu.eduJ0	#
-
-woodrufflab.orgì0	#
-
-savemyfertility.comì0	#
-
-msuhla.chm.msu.edu≥3	#
-
-brains.rad.msu.eduá0	#
-
-msuoutreach.lon-capa.orgîJ	#
-
-autodiscover.law.msu.edui0	#
- 
-woodrufflab.obgyn.msu.eduì0	#
-"
-www.globalyouth.isp.msu.eduD0	#
-$
-phonequeuedisplay.rad.msu.eduá0	#
-
-db.msuhla.chm.msu.edu≥3	#
-
-www.repropedia.comì0	#
-
-www.concussion.msu.eduá0	#
-!
-msuphysicsclub.loncapa.orgîJ	#
-
-registry.gitlab.msu.edug0	#
-
-www.repropedia.orgì0	#
-!
-idp-sfp.itservices.msu.eduö0	#
-
-patient.rad.msu.eduá0	#
-
-beta.advancement.msu.edu™	#
-"
-msuphysicsclub.lon-capa.orgîJ	#
-
-myoiss.msu.eduN0	#
-
-repropedia.msu.eduì0	#
-
-monitor.loncapa.orgïJ	#
-
-www.oirc.isp.msu.eduD0	#
- 
-www.concussionimaging.orgá0	#
-
-events.loncapa.orgñJ	#
-
-sportsmed.msu.eduá0	#
-
-concussionimaging.orgá0	#
-#
-www.apps.advancement.msu.edu™	#
-
-feig.bch.msu.eduÒa	#
-
-dev.mdid.art.msu.edud0	#
-
-testdrive.lite.msu.eduõJ	#
-
-s12.lite.msu.eduìJ	#
-
-researchcal.rad.msu.eduá0	#
-"
-www.sportsnutrition.msu.eduá0	#
-
-monitor.lon-capa.orgïJ	#
-
-fw-ats.bric.msu.edu{	#
-
-apps.advancement.msu.edu™	#
- 
-webapp.msuhla.chm.msu.edu≥3	#
- 
-secure.msuhla.chm.msu.edu≥3	#
-
-repropedia.orgì0	#
-
-www.beta.serve.msu.edu™	#
-
-fw-ats.bric.msu.edu
-{	#
-
-fw-ats.bric.msu.edu-{	#
-
-protegermifertilidad.comì0	#
-
-bps-s2.lite.msu.edu£J	#
-
-www.anatomy.msu.eduá0	#
-
-phonequeue.rad.msu.eduá0	#
-
-bps-s3.lite.msu.edu£J	#
-
-guardmyfertility.comì0	#
-
-www.brains.rad.msu.eduá0	#
-
-bps-s9.lite.msu.edu£J	#
-
-keyring.bric.msu.edu{	#
-
-isavefertility.orgì0	#
-
-beta.alumni.msu.edu™	#
-
-isavefertility.comì0	#
-
-savemyfertility.netì0	#
-
-monitor.lite.msu.eduïJ	#
-
-protectmyfertility.orgì0	#
-
-bps-s1.lite.msu.edu£J	#
-#
-www.beta.advancement.msu.edu™	#
-
-nls.uadv.msu.edu™	#
-
-beta.givingto.msu.edu™	#
-
-guardmyfertility.orgì0	#
-
-bps-s10.lite.msu.edu£J	#
-
-beta.advancement.msu.edu™	#
-
-outreach.lite.msu.eduîJ	#
-
-beta.alumni.msu.edu™	#
-
-dca.rad.msu.eduá0	#
-
-fw-ats.bric.msu.edu/{	#
-
-sandbox.lite.msu.eduúJ	#
-
-beta.serve.msu.edu™	#
-%
-www.spartanperformance.msu.eduá0	#
-
-sharepoint.ctsi.msu.edu{	#
-
-feig.bch.msu.eduÒa	#
-
-as400.rhs.msu.eduœº	#
-
-citrix.cvm.msu.edu=≥	#
-
-fm.ehs.msu.edu‹	#
-
-events.lon-capa.orgñJ	#
-!
-csctxns02.campusad.msu.edu&≥	#
-
-bric.msu.edu{	#
-
-rsgis-home.rsgis.msu.edu∆ˆ	#
-
-mibiomass.rsgis.msu.edu∆ˆ	#
-
-events.lite.msu.eduñJ	#
-&
-preservefertility.obgyn.msu.eduì0	#
-
-www.bric.msu.edu{	#
- 
-www.beta.givingto.msu.edu™	#
-
-beta.givingto.msu.edu™	#
-
-www.beta.serve.msu.edu™	#
- 
-cvmctx02.campusad.msu.edu=≥	#
-
-bps-s4.lite.msu.edu£J	#
-
-biopbprd.ebsp.msu.edu˜	#
- 
-www.beta.givingto.msu.edu™	#
-
-citrix.cvm.msu.edu&≥	#
-
-www.beta.alumni.msu.edu™	#
-
-portal.ebsp.msu.edu˜	#
- 
-dataservices.ebsp.msu.edu˜	#
- 
-storefront.vetmed.msu.edu&≥	#
-
-analytics.bric.msu.edu{	#
-
-www.beta.alumni.msu.edu™	#
-%
-vmc-ctx-licens2.vetmed.msu.edu&≥	#
-
-inteum.icapps.msu.eduPw	#
-
-neuropsychology.msu.edu˜	#
- 
-cvmctx02.campusad.msu.edu&≥	#
-!
-csctxsf01.campusad.msu.edu&≥	#
-
-fw-ats.bric.msu.edu{	#
-
-ntweb11.ais.msu.edu˜	#
- 
-cvmctx01.campusad.msu.edu&≥	#
-
-rfid.msu.edu˜	#
-
-tools.ebsp.msu.edu˜	#
-
-xen.hit.msu.edu=≥	#
-
-fw-ats.bric.msu.edu9{	#
-
-jira.ebsp.msu.edu˜	#
-
-holmesqa.rhs.msu.eduœº	#
-
-fw-ats.bric.msu.edu"{	#
-
-ombudsman.msu.edu˜	#
-
-jboss.ebsp.msu.edu˜	#
- 
-storefront.vetmed.msu.edu=≥	#
-
-beta.serve.msu.edu™	#
-
-xen.cvm.msu.edu&≥	#
-
-maps.rsgis.msu.edu∆ˆ	#
-!
-flintregistry.ctsi.msu.edu3{	#
-
-appmd.ais.msu.edu˜	#
-
-uas.rsgis.msu.edu∆ˆ	#
-
-fw-ats.bric.msu.edu#{	#
-
-web.cvm.msu.edu&≥	#
-
-qmsu00a.rhs.msu.eduœº	#
-
-www.webmail.bric.msu.edu{	#
-
-watsonqa.rhs.msu.eduœº	#
-
-dev.citrix.hit.msu.edu&≥	#
-
-secportal.ebsp.msu.edu˜	#
-
-dcpahonline.msu.edu&≥	#
-!
-csctxns01.campusad.msu.edu&≥	#
-
-qmsu00b.rhs.msu.eduœº	#
-!
-csctxns02.campusad.msu.edu=≥	#
-
-xen.cvm.msu.edu=≥	#
-"
-downloadsapgui.ebsp.msu.edu˜	#
-
-bamboo.ebsp.msu.edu˜	#
-
-www.contact.oss.msu.edu˜	#
-#
-www.beta.advancement.msu.edu™	#
-'
- intranetapps.advancement.msu.eduÄ™	#
-
-fin.ebsp.msu.edu˜	#
-
-sds.rcpd.msu.edu˜	#
-
-citrix.hit.msu.edu&≥	#
-
-rwdt.ebsp.msu.edu˜	#
-%
-vmc-ctx-license.vetmed.msu.edu&≥	#
-
-web.cvm.msu.edu=≥	#
-!
-csctxsf02.campusad.msu.edu&≥	#
-
-www.healthwise.msu.edu˜	#
-
-aid.advancement.msu.edu'™	#
-
-holmes.rhs.msu.eduœº	#
-
-ctlr.msu.edu:¥	#
-
-fisheye.ebsp.msu.edu˜	#
-
-is.rhs.msu.edu)Ω	#
-
-soilweb.spnl.msu.edu?€	#
-
-wireless.msu.edu˜	#
-
-home.rsgis.msu.edu∆ˆ	#
-
-www.etime.msu.edu˜	#
-
-mailprotection.msu.edu˜	#
-!
-csctxns01.campusad.msu.edu=≥	#
-
-citrix.hit.msu.edu=≥	#
-
-books.rcpd.msu.edu˜	#
-
-rsgis.msu.edu∆ˆ	#
-
-bolderit.msu.edu˜	#
-#
-www.coastwatch.rsgis.msu.edu∆ˆ	#
-
-dcpahonline.msu.edu=≥	#
-
-spartanmail.msu.edu˜	#
-
-coastwatch.msu.edu∆ˆ	#
-
-plugin.ebsp.msu.edu˜	#
-%
-vmc-ctx-licens2.vetmed.msu.edu=≥	#
-
-xen.hit.msu.edu&≥	#
-
-www.healtheguide.msu.edu˜	#
-
-www.webenroll.msu.edu˜	#
-
-watson.rhs.msu.eduœº	#
-&
-athultratime.itservices.msu.edu˜	#
-
-www.coastwatch.msu.edu∆ˆ	#
-
-download.ebsp.msu.edu˜	#
-!
-qmsu00a.rhsnet.rhs.msu.eduœº	#
-
-dev.citrix.hit.msu.edu=≥	#
-
-www.ombudsman.msu.edu˜	#
-#
-athmobile.itservices.msu.edu˜	#
-
-reporting.anr.msu.edu˜	#
-
-sirsonline.msu.edu˜	#
-"
-usys-iis.itservices.msu.edu˜	#
-
-etime.msu.edu˜	#
-
-www.fsra.msu.edu˜	#
-
-degnav.msu.edu˜	#
-(
-!ingham-equalization.rsgis.msu.edu∆ˆ	#
-!
-qmsu00b.rhsnet.rhs.msu.eduœº	#
-
-www.degnav.msu.edu˜	#
-
-sis2apps.ais.msu.edu˜	#
-'
- biopbprd.qual.itservices.msu.edu˜	#
-#
-reporting.itservices.msu.edu˜	#
-
-coastwatch.rsgis.msu.edu∆ˆ	#
-
-fsra.msu.edu˜	#
-
-ooi.ebsp.msu.edu˜	#
-
-
-go.msu.edu˜	#
-
-www.stu-info.msu.edu˜	#
-
-www.maps.rsgis.msu.edu∆ˆ	#
-
-ep.ebsp.msu.edu˜	#
-
-bi.ebsp.msu.edu˜	#
-
-mail.msu.edu˜	#
-
-gradplan.msu.edu˜	#
- 
-student-elections.msu.edu˜	#
-
-commonunitcode.msu.edu˜	#
-$
-www.student-elections.msu.edu˜	#
-
-myprofile.rcpd.msu.edu˜	#
-
-maps.msu.edu˜	#
-
-ebs.msu.edu˜	#
-
-herd.msu.edu˜	#
-
-hearlab.msu.edu˜	#
-
-nexus.ebsp.msu.edu˜	#
-
-tourismplan.anr.msu.edu˜	#
-"
-apmadmin.itservices.msu.edu ˜	#
-+
-$mobile.ultrabadge.itservices.msu.edu!˜	#
-
-spartan365.msu.edu˜	#
- 
-assets.itservices.msu.edu ˜	#
-"
-www.neuropsychology.msu.edu˜	#
-
-abuse.msu.edu˜	#
-
-apm.itservices.msu.edu ˜	#
-)
-"athletebookloan.itservices.msu.edu ˜	#
-
-bi.rmi.msu.edu˜	#
-
-mm.ebsp.msu.edu˜	#
-
-hcpimmunize.msu.edu˜	#
-
-myid.msu.edu˜	#
-&
-appportfolio.itservices.msu.edu ˜	#
-
-events.msu.edu˜	#
-
-contact.oss.msu.edu˜	#
-
-caps.itservices.msu.edu ˜	#
-
-coursereserve.msu.edu˜	#
-
-www.bolderit.msu.edu˜	#
-
-tbawareness.msu.edu˜	#
-
-carlos.ular.msu.edu˜	#
-
-biopb.itservices.msu.edu˜	#
-
-keepmsuworking.msu.edu˜	#
-
-www.rfid.msu.edu˜	#
-
-riskmaster.rmi.msu.edu˜	#
-
-tech.msu.edu˜	#
-
-api.search.msu.edu˜	#
-
-hcapp.itservices.msu.edu ˜	#
-
-u.search.msu.edu˜	#
-
-www.besocratic.msu.edu˜	#
-%
-productionservices.ais.msu.edu!˜	#
-
-search.msu.edu˜	#
-%
-www.transfercredit.ais.msu.edu!˜	#
-
-cio.msu.edu˜	#
-
-www.cio.msu.edu˜	#
-
-www.webmemo.ais.msu.edu!˜	#
-!
-www.commonunitcode.msu.edu˜	#
-
-www.clifms.msu.edu˜	#
-
-www.sis2apps.ais.msu.edu˜	#
-
-mystuinfo.msu.edu˜	#
-
-inserts.ctlr.msu.edu˜	#
-
-www.stuinfo.msu.edu˜	#
-%
-rptdelivery.itservices.msu.edu ˜	#
- 
-eem.itservicedesk.msu.edu+˜	#
-
-clifms.ais.msu.edu!˜	#
-
-www.security.ais.msu.edu!˜	#
-
-keywords.msu.edu˜	#
-
-www.carlos.ular.msu.edu˜	#
-
-mba.broad.msu.eduS˜	#
-
-www.herd.msu.edu˜	#
-
-earm.itservices.msu.edu ˜	#
-
-adistran.ais.msu.edu!˜	#
-
-seu.itservices.msu.edu ˜	#
-
-stu-info.msu.edu˜	#
-
-secureit.msu.edu˜	#
-
-stuinfo.msu.edu˜	#
-
-security.ais.msu.edu!˜	#
-(
-!systempassword.itservices.msu.edu ˜	#
-%
-webcluster1.itservices.msu.edu˜	#
-
-alm.itservices.msu.edu#˜	#
-
-msuid.ais.msu.edu!˜	#
-
-www.soct.msu.edu˜	#
-
-internal.broad.msu.eduS˜	#
-
-www.egradfel.msu.edu˜	#
-
-clifms.msu.edu˜	#
-
-docstatus.ais.msu.edu!˜	#
-
-citrix.hit.msu.edu?˜	#
- 
-uss.itservicedesk.msu.edu"˜	#
-
-ppm.tech.msu.edu2˜	#
- 
-pam.itservicedesk.msu.edu+˜	#
-!
-executivemba.broad.msu.eduS˜	#
-!
-usysapi.itservices.msu.edu ˜	#
-
-hvwsoaprd1.nam3.msu.edu
-#
-
-itservicedesk.msu.edu+˜	#
-0
-)spartanimpactdashboard.itservices.msu.edu ˜	#
-'
- gartnerportal.itservices.msu.edu ˜	#
-
-www.elearn.hc.msu.edu?˜	#
-
-wcu.itservices.msu.edu ˜	#
- 
-eem.itservicedesk.msu.edu"˜	#
-'
- visualizer.itservicedesk.msu.edu"˜	#
-#
-docstatus.itservices.msu.edu ˜	#
-
-webenroll.msu.edu˜	#
-
-hvwsoaprd2.nam3.msu.edu
-#
-
-marketing.broad.msu.eduS˜	#
-
-fpid.itservices.msu.edu ˜	#
-
-www.msuid.ais.msu.edu!˜	#
-
-demmer.broad.msu.eduS˜	#
-"
-campdata.itservices.msu.edu ˜	#
-
-itservicedesk.msu.edu"˜	#
-
-www.stuinfo.ais.msu.edu!˜	#
-
-elearn.hc.msu.edu?˜	#
- 
-www.coursereserve.msu.edu˜	#
-(
-!supportauto.itservicedesk.msu.edu"˜	#
-
-controlpanel.ais.msu.edu!˜	#
-
-www.tech.msu.edu˜	#
-
-www.hcpimmunize.msu.edu˜	#
-
-www.msu.eduE˜	#
-!
-vdi-a-cs2.campusad.msu.edu
-#
-"
-vdi-a-idm1.campusad.msu.edu
-#
-(
-!supportauto.itservicedesk.msu.edu+˜	#
-"
-security.itservices.msu.eduH˜	#
-
-www.gradinfo.msu.edu˜	#
-"
-imaccess.itservices.msu.edu ˜	#
-
-uphysapps.msu.edu˜	#
-
-mbacareers.broad.msu.eduS˜	#
-!
-payrollexpense.ais.msu.edu!˜	#
-
-www.oissinfo.ais.msu.edu!˜	#
-
-shcep.broad.msu.eduS˜	#
-
-edp.broad.msu.eduS˜	#
-
-msuhealth.hc.msu.edu?˜	#
-"
-vdi-a-epc2.campusad.msu.edu
-#
-
-zoom.msu.edu˜	#
-
-accounting.broad.msu.eduS˜	#
-
-msuid.itservices.msu.edu!˜	#
-
-jira.itservices.msu.edu ˜	#
-
-fals.itservices.msu.edu ˜	#
-!
-vdi-b-cs1.campusad.msu.edu
-#
-#
-mobile.itservicedesk.msu.edu"˜	#
-)
-"hospitatlitybusiness.broad.msu.eduS˜	#
-)
-"www.productionservices.ais.msu.edu!˜	#
-
-exceed.broad.msu.eduS˜	#
- 
-www.aiseforms.ais.msu.edu!˜	#
- 
-webdoc.itservices.msu.edu ˜	#
-
-www.msuhealth.hc.msu.edu?˜	#
-
-tms-sass.ais.msu.edu!˜	#
-
-vdi-epc.campusad.msu.edu
-#
-(
-!studentintltax.itservices.msu.edu ˜	#
-
-acs.itservices.msu.edu ˜	#
--
-&spartanimpactportal.itservices.msu.edu ˜	#
-
-scholendow2.ais.msu.edu!˜	#
- 
-www.dataadmin.ais.msu.edu!˜	#
-!
-vdi-a-cs2.campusad.msu.edu#
-
-www.maps.msu.edu˜	#
-
-roomscheduling.msu.edue˜	#
-%
-studentadminportal.chm.msu.edu<˜	#
-
-hvwsoaprd3.nam3.msu.edu
-#
-
-aiseforms.ais.msu.edu!˜	#
-
-www.cabs.msu.eduZ˜	#
-
-hvuagprd1.nam3.msu.edu#
-
-mbp.broad.msu.eduS˜	#
-
-ras.itservices.msu.edu ˜	#
-
-myhealth.msu.edu?˜	#
-
-ie.broad.msu.eduS˜	#
-
-www.broad.msu.eduS˜	#
-"
-vdi-b-uag2.campusad.msu.edu#
-
-hvuagprdi1.nam3.msu.edu#
-!
-vdi-a-cs1.campusad.msu.edu#
-!
-hvepcprd1.campusad.msu.edu
-#
- 
-vdi-a-cs.campusad.msu.edu#
-!
-webmemo.itservices.msu.edu!˜	#
-"
-vdi-a-idm1.campusad.msu.edu#
-"
-vdi-a-epc1.campusad.msu.edu#
-&
-reporting.itservicedesk.msu.edu"˜	#
-
-mymsuhealth.hc.msu.edu?˜	#
- 
-www.itservicedesk.msu.edu+˜	#
-!
-vdi-a-uag.campusad.msu.edu
-#
-%
-webcluster3.itservices.msu.edu!˜	#
-"
-vdi-a-uag1.campusad.msu.edu
-#
-
-hvuagprd1.nam3.msu.edu#
-!
-studentintltax.ais.msu.edu!˜	#
-
-clode.broad.msu.eduS˜	#
-%
-aissecuritycontact.ais.msu.edu!˜	#
-
-hvwsoaprd3.nam3.msu.edu#
-
-cabs.msu.eduZ˜	#
-
-axia.broad.msu.eduS˜	#
-!
-vdi-a-uag.campusad.msu.edu#
-
-ultrabadge.ais.msu.edu!˜	#
-!
-paymentsupport.ais.msu.edu!˜	#
-
-sas2.ais.msu.edu!˜	#
-!
-vdi-a-uag.campusad.msu.edu#
-!
-vdi-a-cs1.campusad.msu.edu#
-!
-hvepcprd2.campusad.msu.edu#
-%
-plant-transformation.glbrc.orgÌ#
-
-full.vpn.msu.edu&˙	#
-
-stuinfo.ais.msu.edu!˜	#
-
-hvuagprd1.nam3.msu.edu
-#
-
-mispartanimpact.msu.edut˜	#
-
-finance.broad.msu.eduS˜	#
-"
-vdi-a-idm2.campusad.msu.edu
-#
-"
-vdi-a-epc2.campusad.msu.edu#
-!
-vdi-b-cs1.campusad.msu.edu#
-"
-vdi-a-idm3.campusad.msu.edu#
- 
-uptime.itservices.msu.edu ˜	#
-
-baf.glbrc.msu.eduÌ#
-"
-genomics-sync.glbrc.msu.eduÌ#
-"
-vdi-a-epc1.campusad.msu.edu
-#
-"
-vdi-a-uag2.campusad.msu.edu#
-!
-hvepcprd1.campusad.msu.edu#
-
-msmc-sync.glbrc.msu.eduÌ#
-"
-vdi-a-idm3.campusad.msu.edu#
-
-hvwsoaprd2.nam3.msu.edu#
-"
-vdi-a-idm1.campusad.msu.edu#
-
-	cmich.edu
-@!#
-
-	cmich.edu@!#
-
-ts.glbrc.msu.edu"Ì#
-!
-vdi-a-cs1.campusad.msu.edu#
-
-hvuagprdi2.nam3.msu.edu
-#
-
-hvuagprd2.nam3.msu.edu
-#
-
-hvuagprdi1.nam3.msu.edu#
-
-hvwsoaprd2.nam3.msu.edu#
-
-msu.eduE˜	#
-#
-readonlymsuhealth.hc.msu.edu?˜	#
-
-www.addrarch.ais.msu.edu!˜	#
-
-erequest.asmsu.msu.edup˜	#
-!
-hvepcprd2.campusad.msu.edu#
-
-weekendmba.broad.msu.eduS˜	#
-
-	cmich.edu'@!#
-
-	cmich.eduP@!#
-
-	cmich.eduO@!#
-"
-vdi-a-idm2.campusad.msu.edu#
-
-hvwsoaprd3.nam3.msu.edu#
-
-www.mss.msu.eduU˜	#
-!
-vdi-a-cs1.campusad.msu.edu
-#
-"
-vdi-b-uag1.campusad.msu.edu#
-
-	cmich.eduF@!#
-
-vdi-uag.campusad.msu.edu#
-
-brand.msu.edu]˜	#
-
-	cmich.eduN@!#
-
-vdi.msu.edu
-#
-'
- makebusinesshappen.broad.msu.eduS˜	#
-
-	cmich.eduM@!#
-
-hvuagprdi1.nam3.msu.edu#
-
-lear.broad.msu.eduS˜	#
-"
-vdi-a-idm1.campusad.msu.edu#
-
-railway.broad.msu.eduS˜	#
-&
-midlandvaluechain.broad.msu.eduS˜	#
-!
-hvepcprd2.campusad.msu.edu
-#
-
-	cmich.eduE@!#
-"
-vdi-b-uag1.campusad.msu.edu#
-
-hvuagprd2.nam3.msu.edu#
-
-vdi-uag.campusad.msu.edu#
-"
-vdi-a-idm2.campusad.msu.edu#
-"
-vdi-a-idm2.campusad.msu.edu#
-"
-vdi-b-uag2.campusad.msu.edu#
-
-hvuagprd2.nam3.msu.edu#
- 
-supplychain.broad.msu.eduS˜	#
-!
-hvepcprd2.campusad.msu.edu#
- 
-vdi-a-cs.campusad.msu.edu#
-"
-vdi-a-epc1.campusad.msu.edu#
-!
-vdi-b-cs2.campusad.msu.edu#
-"
-vdi-b-uag1.campusad.msu.edu
-#
-
-	cmich.edu,@!#
-"
-vdi-b-uag1.campusad.msu.edu#
-"
-vdi-a-uag1.campusad.msu.edu#
-
-	cmich.eduê@!#
-
-vdi-uag.campusad.msu.edu
-#
-
-	cmich.edu@!#
-
-	cmich.eduî@!#
-
-	cmich.edu*@!#
- 
-vdi-a-cs.campusad.msu.edu#
-
-vdi.msu.edu#
-
-	cmich.edu‰@!#
-"
-vdi-a-uag1.campusad.msu.edu#
-"
-vdi-a-uag2.campusad.msu.edu#
-!
-hvepcprd2.campusad.msu.edu#
-
-vdi-epc.campusad.msu.edu#
-"
-vdi-a-uag1.campusad.msu.edu#
-!
-vdi-a-cs2.campusad.msu.edu#
-
-vdi-epc.campusad.msu.edu#
-
-vdi.msu.edu#
- 
-vdi-a-cs.campusad.msu.edu#
-"
-vdi-a-uag2.campusad.msu.edu
-#
-
-	cmich.edu·@!#
-"
-vdi-a-uag1.campusad.msu.edu#
-
-hvuagprd2.nam3.msu.edu#
-
-hvwsoaprd1.nam3.msu.edu#
-"
-vdi-b-uag1.campusad.msu.edu#
-"
-vdi-a-idm3.campusad.msu.edu#
-
-	cmich.edu}@!#
-
-hvwsoaprd1.nam3.msu.edu#
-"
-vdi-a-epc2.campusad.msu.edu#
-"
-vdi-a-idm1.campusad.msu.edu#
-"
-vdi-a-epc2.campusad.msu.edu#
-
-	cmich.eduT@!#
-
-vdi-epc.campusad.msu.edu#
-"
-vdi-a-uag2.campusad.msu.edu#
-
-hvuagprdi2.nam3.msu.edu#
-
-hvwsoaprd2.nam3.msu.edu#
-
-	cmich.eduQ@!#
-
-	cmich.edut@!#
-
-hvwsoaprd1.nam3.msu.edu#
-"
-vdi-a-epc2.campusad.msu.edu#
-
-hfcc.netOÀ2
-
-hfcc.eduPÀ2
-!
-hvepcprd1.campusad.msu.edu#
- 
-vdi-a-cs.campusad.msu.edu
-#
-
-	cmich.edu)@!#
-
-hvwsoaprd3.nam3.msu.edu#
-
-vdi.msu.edu#
-
-hvuagprdi2.nam3.msu.edu#
-
-hvuagprd1.nam3.msu.edu#
-
-	cmich.edu:@!#
-
-hfcc.edu^À2
-
-hfcc.eduÿÀ2
-"
-vdi-b-uag2.campusad.msu.edu#
-
-hvuagprdi2.nam3.msu.edu#
-!
-vdi-b-cs2.campusad.msu.edu#
-"
-vdi-a-idm2.campusad.msu.edu#
-
-vdi-uag.campusad.msu.edu#
-
-	cmich.eduC@!#
-
-test-mtdvm.oaklandcc.eduÓÏsJ
-
-hfcc.eduQÀ2
-
-	cmich.eduç@!#
-"
-vdi-a-epc1.campusad.msu.edu#
-!
-vdi-b-cs2.campusad.msu.edu
-#
-
-hvuagprdi1.nam3.msu.edu#
-
-	cmich.eduî@!#
-
-	cmich.edu˛C!#
-
-turn.oaklandcc.edu°ÌsJ
-
-hvuagprd1.nam3.msu.edu#
-!
-vdi-b-cs2.campusad.msu.edu#
-
-mobility.oaklandcc.edu¢ÌsJ
-
-hfcc.edu$À2
-
-	cmich.edu=@!#
-"
-vdi-a-epc1.campusad.msu.edu#
-
-mitel.oaklandcc.edu¢ÌsJ
-
-hvwsoaprd3.nam3.msu.edu#
-
-mt-dvm.oaklandcc.edu¢ÌsJ
-
-hfcc.net\À2
-
-hvwsoaprd1.nam3.msu.edu#
-!
-vdi-a-cs2.campusad.msu.edu#
-
-acd.oaklandcc.edu¢ÏsJ
-
-	cmich.eduV@!#
-
-	cmich.eduD!#
-"
-vdi-a-uag2.campusad.msu.edu#
-
-bnadm01.davenport.eduI∆ B
-
-test-mtecc.oaklandcc.eduÓÏsJ
-
-testegw.oaklandcc.eduÓÌsJ
-
-	cmich.edu+@!#
-"
-view01.cyberrange.merit.edu·>#
-
-hfcc.edugÀ2
-
-mt-ecc.oaklandcc.eduÌÌsJ
-
-	cmich.edu÷@!#
-
-hvwsoaprd2.nam3.msu.edu#
- 
-degreeplan2.davenport.edu>∆ B
-
-davenport.edu4∆ B
-
-conference.oaklandcc.edu°ÌsJ
-
-	cmich.eduB@!#
-
-davenport.edu#∆ B
-
-davenport.eduk¿ B
-
-	cmich.edu`@!#
-
-davenport.eduj¿ B
-
-mt-ecc.oaklandcc.edu¢ÏsJ
-
-hvuagprd2.nam3.msu.edu#
-
-infomart.oaklandcc.edu~ÏsJ
-
-remote.oaklandcc.eduÇÏsJ
-
-	cmich.eduR@!#
-
-vdi-uag.campusad.msu.edu#
-
-	cmich.eduë@!#
- 
-mt-director.oaklandcc.edu¢ÌsJ
-
-mobility.oaklandcc.edu¢ÏsJ
-!
-vdi-a-uag.campusad.msu.edu#
-"
-view01.cyberrange.merit.edu·>#
-
-bnssb04.davenport.eduM∆ B
-
-oaklandcc.edu¡ÏsJ
-
-	cmich.eduÕ@!#
-
-	cmich.edu_@!#
-
-conference.oaklandcc.eduÌÌsJ
-
-hfcc.eduGÀ2
-
-testacd.oaklandcc.eduÌsJ
-
-	cmich.eduND!#
-
-turn.oaklandcc.edu¢ÏsJ
-
-shoretel.oaklandcc.eduÔÌsJ
-
-	cmich.edu@@!#
-
-	cmich.eduOD!#
-
-www.oaklandcc.edu¡ÏsJ
-
-	cmich.eduS@!#
-!
-netlabve.cot.davenport.eduÀ› B
-
-vdi.oaklandcc.edu¨ÌsJ
-
-davenport.edu^∆ B
-
-hfcc.edu3À2
- 
-mt-director.oaklandcc.eduÌÌsJ
-
-	cmich.edun@!#
-!
-vdi-b-cs1.campusad.msu.edu#
- 
-mt-director.oaklandcc.edu¢ÏsJ
-
-cwpaygate.oaklandcc.eduÌsJ
-
-mitel.oaklandcc.edu°ÌsJ
-
-davenport.edu$∆ B
-
-bnssb02.davenport.eduK∆ B
-
-mt-ecc.oaklandcc.edu¢ÌsJ
-
-testturn.oaklandcc.eduÓÏsJ
-
-itvdi.oaklandcc.edu´ÌsJ
-
-reporting.davenport.eduQ∆ B
-
-mitel.oaklandcc.edu¢ÏsJ
-$
-test-mtdirector.oaklandcc.eduÌsJ
-
-bnssb03.davenport.eduL∆ B
-
-testrast.oaklandcc.eduÌsJ
-
-	cmich.edu
-D!#
-
-shoretel.oaklandcc.edu°ÌsJ
-
-test-mtdvm.oaklandcc.eduÌsJ
-
-egw.oaklandcc.edu¢ÏsJ
-
-rast.oaklandcc.edu°ÌsJ
-
-infomart.oaklandcc.edu~ÌsJ
-
-	cmich.edu)D!#
-
-testmitel.oaklandcc.eduÓÏsJ
-
-	cmich.edu§@!#
-
-turn.oaklandcc.eduÌÌsJ
-
-mt-dvm.oaklandcc.edu°ÌsJ
-
-rp.oaklandcc.edu°ÌsJ
-
-conference.oaklandcc.edu¢ÌsJ
-
-turn.oaklandcc.edu¢ÌsJ
-
-	cmich.eduî@!#
-
-conference.oaklandcc.edu¢ÏsJ
-
-testegw.oaklandcc.eduÙÌsJ
-
-test-mtecc.oaklandcc.eduÌsJ
-
-mobility.oaklandcc.edu°ÌsJ
-
-mt-dvm.oaklandcc.edu¢ÏsJ
- 
-mt-director.oaklandcc.edu°ÌsJ
-
-egw.oaklandcc.edu¢ÌsJ
-
-turn.oaklandcc.eduÔÌsJ
-
-mobility.oaklandcc.eduÌÌsJ
-
-testmitel.oaklandcc.eduÌsJ
-
-testegw.oaklandcc.eduÓÏsJ
-
-vdi.oaklandcc.edu¨ÌsJ
-
-testrp.oaklandcc.eduÙÌsJ
-
-mt-dvm2.oaklandcc.edu¢ÌsJ
-
-testegw.oaklandcc.eduÌsJ
-!
-testmobility.oaklandcc.eduÙÌsJ
-
-egw.oaklandcc.edu°ÌsJ
-
-itvdi.oaklandcc.edu´ÌsJ
-
-	cmich.eduﬁ@!#
-!
-testmobility.oaklandcc.eduÓÏsJ
-
-mlbpa.davenport.edu`∆ B
-
-acd.oaklandcc.edu°ÌsJ
-
-testturn.oaklandcc.eduÌsJ
-
-testturn.oaklandcc.eduÓÌsJ
-
-davenport.edua∆ B
-
-testvsa.oaklandcc.eduÌsJ
-
-rp.oaklandcc.edu¢ÌsJ
-
-testrp.oaklandcc.eduÌsJ
-
-testrp.oaklandcc.eduÓÌsJ
-
-shoretel.oaklandcc.eduÌÌsJ
-
-mt-dvm2.oaklandcc.eduÌÌsJ
-
-test-mtecc.oaklandcc.eduÓÌsJ
-
-test-mtdvm.oaklandcc.eduÙÌsJ
-
-testacd.oaklandcc.eduÙÌsJ
-
-testrp.oaklandcc.eduÓÏsJ
-
-rast.oaklandcc.edu¢ÏsJ
-
-mitel.oaklandcc.eduÌÌsJ
-
-testturn.oaklandcc.eduÙÌsJ
-
-ssomanager.davenport.eduR∆ B
-
-remote.oaklandcc.eduÇÌsJ
-
-myocc.oaklandcc.eduâÌsJ
-
-acd.oaklandcc.edu¢ÌsJ
-
-testvsa.oaklandcc.eduÓÏsJ
-
-mitel.oaklandcc.eduÔÌsJ
-
-bnprodssb3.davenport.edu*∆ B
-
-testrast.oaklandcc.eduÙÌsJ
-
-testrast.oaklandcc.eduÓÏsJ
-
-mt-dvm2.oaklandcc.eduÔÌsJ
-!
-testmobility.oaklandcc.eduÌsJ
-
-testacd.oaklandcc.eduÓÏsJ
-
-psprodes.grcc.eduTòtJ
-
-testrast.oaklandcc.eduÓÌsJ
-
-ibprod.grcc.eduTòtJ
-
-acd.oaklandcc.eduÔÌsJ
-
-rast.oaklandcc.edu¢ÌsJ
-
-multiplan.oaklandcc.eduÌsJ
-
-psprodps1.grcc.eduTòtJ
-
-guac2.grcc.eduòtJ
-
-psprodw3.grcc.eduTòtJ
-
-courses.grcc.eduUòtJ
-
-	cmich.eduã@!#
-
-mt-ecc.oaklandcc.edu°ÌsJ
-
-fsprod.grcc.eduTòtJ
-
-hrprod.grcc.eduUòtJ
-
-fsprod.grcc.eduUòtJ
-
-testacd.oaklandcc.eduÓÌsJ
-$
-test-mtdirector.oaklandcc.eduÓÌsJ
-
-mt-dvm2.oaklandcc.edu°ÌsJ
-
-psprodae1.grcc.eduTòtJ
-
-psprodw4-2021.grcc.eduTòtJ
-
-courses.grcc.eduTòtJ
-
-rp.oaklandcc.eduÔÌsJ
-
-apps.oaklandcc.edu∞ÌsJ
-
-psproda4-2021.grcc.eduTòtJ
-
-imaging.oaklandcc.eduñÌsJ
-
-psproda1.grcc.eduUòtJ
-
-rast.oaklandcc.eduÔÌsJ
-
-psprodw1.grcc.eduTòtJ
-
-psprodes3.grcc.eduTòtJ
-
-csprod.grcc.eduTòtJ
-
-psprodw1.grcc.eduUòtJ
-
-psprodps2.grcc.eduTòtJ
-
-csprod.grcc.eduUòtJ
-
-hrprod.grcc.edunòtJ
-
-psprodw3.grcc.edunòtJ
-
-psprodps1-2021.grcc.eduTòtJ
-
-rast.oaklandcc.eduÌÌsJ
-
-psprodw2.grcc.eduTòtJ
-
-psprodes1-2021.grcc.eduTòtJ
-
-courses.grcc.edunòtJ
-
-psprodes2-2021.grcc.eduUòtJ
-
-ibprod.grcc.eduUòtJ
-
-psprodes2.grcc.eduTòtJ
-
-psprodes1.grcc.eduUòtJ
-
-psproda1.grcc.eduTòtJ
-
-ibcsprod.grcc.eduTòtJ
-
-apps.oaklandcc.edu∞ÌsJ
-
-psprodes2.grcc.eduUòtJ
- 
-mt-director.oaklandcc.eduÔÌsJ
-
-psproda4.grcc.eduTòtJ
-
-psprodes3.grcc.edunòtJ
-
-psprodps2-2021.grcc.eduTòtJ
-
-psprodes3-2021.grcc.eduUòtJ
-
-ibepprod.grcc.eduUòtJ
-
-psproda2.grcc.eduUòtJ
-
-ibepprod.grcc.eduTòtJ
-
-conference.oaklandcc.eduÔÌsJ
-
-testvsa.oaklandcc.eduÓÌsJ
-
-psprodw4.grcc.eduTòtJ
-
-oc.grcc.eduoòtJ
-
-psprodes1.grcc.eduTòtJ
-
-hrprod.grcc.eduTòtJ
-
-psprodw3.grcc.eduoòtJ
-
-psproda3-2021.grcc.eduTòtJ
-
-egw.oaklandcc.eduÌÌsJ
-
-psprodes1-2021.grcc.eduoòtJ
-
-csprod.grcc.eduúòtJ
-
-ibhrprod.grcc.edunòtJ
-
-psprodw4-2021.grcc.eduoòtJ
-
-vpn.oaklandcc.edueÌsJ
-
-ibcsprod.grcc.eduoòtJ
-
-oc.grcc.eduTòtJ
-
-psprodw2-2021.grcc.eduTòtJ
-
-psprodes1-2021.grcc.eduUòtJ
-
-ibfsprod.grcc.eduTòtJ
-
-test-mtecc.oaklandcc.eduÙÌsJ
-
-psproda4.grcc.eduUòtJ
-
-ibcsprod.grcc.eduUòtJ
-
-psproda1-2021.grcc.edunòtJ
-
-psproda4-2021.grcc.edunòtJ
-
-courses.grcc.eduúòtJ
-
-epprod.grcc.eduúòtJ
-
-psprodw1-2021.grcc.eduTòtJ
-
-psprodes.grcc.edunòtJ
-
-psprodae1-2021.grcc.eduUòtJ
-
-rp.oaklandcc.eduÌÌsJ
-
-ibepprod.grcc.eduoòtJ
-
-ibhrprod.grcc.eduTòtJ
-
-psprodw4-2021.grcc.eduUòtJ
-
-guac.grcc.eduòtJ
-
-psproda2.grcc.edunòtJ
-
-psproda1-2021.grcc.eduUòtJ
-
-psprodps1-2021.grcc.edunòtJ
-
-mt-ecc.oaklandcc.eduÔÌsJ
-
-testmitel.oaklandcc.eduÙÌsJ
-
-psprodw2-2021.grcc.eduUòtJ
-$
-test-mtdirector.oaklandcc.eduÙÌsJ
-
-classclimate.grcc.eduãòtJ
-
-psprodes3.grcc.eduoòtJ
-
-psproda3.grcc.eduoòtJ
-
-psprodes2-2021.grcc.eduTòtJ
-
-psprodw4.grcc.eduUòtJ
-
-csprod.grcc.edunòtJ
-
-psproda1-2021.grcc.eduTòtJ
-
-psproda2-2021.grcc.eduUòtJ
-
-egw.oaklandcc.eduÔÌsJ
-
-psprodes.grcc.eduUòtJ
-
-testvsa.oaklandcc.eduÙÌsJ
-
-psproda2.grcc.eduTòtJ
-
-psprodw4.grcc.eduoòtJ
-
-psproda3.grcc.eduUòtJ
-
-epprod.grcc.eduTòtJ
-
-psprodps2.grcc.edunòtJ
-
-epprod.grcc.eduUòtJ
-
-psprodps1.grcc.eduUòtJ
-
-ibfsprod.grcc.eduúòtJ
-
-psprodw2-2021.grcc.edunòtJ
-
-ccsurveys.grcc.eduãòtJ
-
-psproda4.grcc.edunòtJ
-
-psproda3.grcc.edunòtJ
-
-psprodw1-2021.grcc.edunòtJ
-
-psprodes2-2021.grcc.edunòtJ
-
-fsprod.grcc.eduúòtJ
-
-ibfsprod.grcc.eduUòtJ
-
-psprodes1.grcc.eduoòtJ
-
-psprodw3-2021.grcc.eduTòtJ
-
-psprodps1.grcc.edunòtJ
-
-pskbprod.grcc.eduTòtJ
-
-psproda2-2021.grcc.eduTòtJ
-
-ibepprod.grcc.edunòtJ
-
-psprodw2.grcc.eduUòtJ
-
-pskbprod.grcc.edunòtJ
-
-fsprod.grcc.edunòtJ
-
-ibcsprod.grcc.eduúòtJ
-
-oc.grcc.eduUòtJ
-
-psproda3.grcc.eduúòtJ
-
-psprodae1-2021.grcc.eduTòtJ
-
-psproda3-2021.grcc.eduUòtJ
-
-psprodes1-2021.grcc.edunòtJ
-
-psprodps2-2021.grcc.edunòtJ
-
-psprodes2.grcc.eduoòtJ
-
-psproda2-2021.grcc.eduoòtJ
-
-psprodae1.grcc.eduúòtJ
-
-psprodes1-2021.grcc.eduúòtJ
-
-ibprod.grcc.edunòtJ
-
-psproda3-2021.grcc.eduúòtJ
-
-psprodes2.grcc.edunòtJ
-
-ibcsprod.grcc.edunòtJ
-
-psprodw2.grcc.edunòtJ
-
-psprodae1-2021.grcc.edunòtJ
-
-psproda4-2021.grcc.eduUòtJ
-
-psprodps1.grcc.eduoòtJ
-
-psproda3.grcc.eduTòtJ
-
-psproda4-2021.grcc.eduúòtJ
-
-psprodps1-2021.grcc.eduúòtJ
-
-jobs.grcc.eduoòtJ
-
-ibfsprod.grcc.edunòtJ
-
-psprodps2.grcc.eduUòtJ
-
-oc.grcc.edunòtJ
-
-psprodae1-2021.grcc.eduúòtJ
-
-psproda3-2021.grcc.edunòtJ
-
-pskbprod.grcc.eduUòtJ
-
-psproda2-2021.grcc.eduúòtJ
-
-psprodae1.grcc.eduoòtJ
-
-psprodw1.grcc.edunòtJ
-
-psprodps1-2021.grcc.eduoòtJ
-
-psproda1.grcc.edunòtJ
-
-hrprod.grcc.eduúòtJ
-
-psprodw1-2021.grcc.eduUòtJ
-
-ibprod.grcc.eduoòtJ
-
-ibs-lb.colorado.eduûCäÄ
-
-psprodw2-2021.grcc.eduoòtJ
-
-psprodw2.grcc.eduúòtJ
-
-jobs.grcc.eduúòtJ
-
-psproda3-2021.grcc.eduoòtJ
-"
-buffportal.gtm.colorado.edu^CäÄ
-*
-#external-identikey.gtm.colorado.edu[CäÄ
-
-epprod.grcc.edunòtJ
-
-psprodw3-2021.grcc.eduUòtJ
-
-psproda1-2021.grcc.eduúòtJ
-
-jobs.grcc.eduUòtJ
-
-psprodes1.grcc.edunòtJ
-
-ibprod.grcc.eduúòtJ
-
-psprodps2-2021.grcc.eduoòtJ
-
-oc.grcc.eduúòtJ
-
-psprodes3-2021.grcc.edunòtJ
-
-psprodes.grcc.eduoòtJ
-
-psprodps1-2021.grcc.eduUòtJ
-
-psprodae1.grcc.edunòtJ
-
-psprodw4-2021.grcc.edunòtJ
-
-7pts.colorado.edu#\äÄ
-
-arroyo.colorado.eduBFäÄ
-
-psprodes2-2021.grcc.eduúòtJ
-
-psprodps2.grcc.eduúòtJ
-
-psprodw3-2021.grcc.eduúòtJ
-
-psproda1.grcc.eduoòtJ
-
-psprodw3.grcc.eduúòtJ
-
-ibepprod.grcc.eduúòtJ
-
-psprodw1-2021.grcc.eduoòtJ
-
-psproda4.grcc.eduúòtJ
-
-psprodes3-2021.grcc.eduoòtJ
-"
-identikey-comp.colorado.edu[CäÄ
-
-psproda2.grcc.eduúòtJ
-
-epprod.grcc.eduoòtJ
-
-pskbprod.grcc.eduoòtJ
-
-dosequis.colorado.eduFHäÄ
-"
-biof-imagewiki.colorado.edu/]äÄ
-
-www.theoryon.orgCäÄ
-
-atoc-test.colorado.eduIäÄ
-
-theoryon.orgCäÄ
-
-psproda1-2021.grcc.eduoòtJ
-
-psprodps2-2021.grcc.eduúòtJ
-
-ofa.colorado.eduDäÄ
-
-atoc.colorado.eduIäÄ
-
-psprodes3.grcc.eduUòtJ
-
-psprodw4-2021.grcc.eduúòtJ
-
-identikey.colorado.edu[CäÄ
-"
-identikey-spsc.colorado.edu[CäÄ
-
-ibhrprod.grcc.eduúòtJ
-
-courses.grcc.eduoòtJ
-
-psprodw3-2021.grcc.eduoòtJ
-
-psproda2.grcc.eduoòtJ
-
-psprodes1.grcc.eduúòtJ
-
-regnet.colorado.eduDäÄ
-
-tungsten.grcc.eduùòtJ
-
-monitor.grcc.eduôtJ
-
-prtg.grcc.eduôtJ
-
-ibhrprod.grcc.eduoòtJ
-
-pshop.grcc.edu®òtJ
-
-camra.colorado.edu8IäÄ
-
-ibs-ibs.colorado.edu®CäÄ
-
-jobs.grcc.edunòtJ
-
-oit-web01.colorado.edu\äÄ
-
-psproda4-2021.grcc.eduoòtJ
-
-cln.colorado.edu\äÄ
-
-hazards.colorado.eduèCäÄ
-
-hdssecrets.colorado.eduWäÄ
-#
-buffportal-comp.colorado.edu^CäÄ
-
-psprodw2-2021.grcc.eduúòtJ
-!
-leeds-faculty.colorado.eduCäÄ
-
-spot.colorado.edu\äÄ
-
-emsrmview.colorado.edu#\äÄ
-
-hdsapps.colorado.eduaäÄ
- 
-skillscenter.colorado.eduFHäÄ
-
-hdsf5.colorado.eduäÄ
-
-psprodps1.grcc.eduúòtJ
-
-psprodes2.grcc.eduúòtJ
-
-psprodw1.grcc.eduúòtJ
-
-euclid.colorado.edu9IäÄ
-
-cspv.colorado.edu¢CäÄ
-
-printshop.grcc.edu®òtJ
-
-ofainternal.colorado.eduDäÄ
-
-emscampusvc.colorado.edu#\äÄ
-
-beesneeds.colorado.edu\äÄ
-
-psprodes3.grcc.eduúòtJ
-
-psprodes2-2021.grcc.eduoòtJ
--
-&learningassistantalliance.colorado.edu\äÄ
-
-bs.colorado.eduûCäÄ
-
-pskbprod.grcc.eduúòtJ
-
-psprodes.grcc.eduúòtJ
-
-qijc.colorado.edu$DäÄ
-
-ceps.colorado.eduÀäÄ
-
-psprodw1-2021.grcc.eduúòtJ
-
-storm-test.colorado.eduIäÄ
-
-emsweb.colorado.edu#\äÄ
-
-garcealab.colorado.eduFHäÄ
-
-eprint.grcc.edu®òtJ
-
-sareports.colorado.eduäÄ
-
-qijc-test.colorado.edu$DäÄ
-
-ibs.colorado.eduûCäÄ
-
-ibs-legacy.colorado.eduÜCäÄ
-
-bioliteracy.colorado.eduFHäÄ
-
-mail.cubookstore.comçeäÄ
-
-math.colorado.edu9IäÄ
-!
-cucontent-new.colorado.educÅäÄ
-
-niwotlter.colorado.edu2WäÄ
-
-lmsmanager.colorado.eduÏäÄ
-)
-"demo.learningassistantalliance.org\äÄ
-
-musm-apps-2.colorado.edu	\äÄ
-
-hoengerlab.colorado.eduFHäÄ
-
-nanoserver2.colorado.edu\äÄ
-
-casa-test.colorado.eduëIäÄ
-%
-converge-training.colorado.eduéCäÄ
-
-psprodes3-2021.grcc.eduúòtJ
-
-ceae-server.colorado.eduIäÄ
-
-bio3d.colorado.eduXHäÄ
-
-fiji-dtn.colorado.edu2]äÄ
-
-ceps.spacescience.orgÀäÄ
-
-lpcams.cubookstore.comõeäÄ
-
-mcdbiology.colorado.eduFHäÄ
-
-studentjobs.colorado.eduDäÄ
-
-mcdb70.colorado.eduFHäÄ
-
-registrar.colorado.eduDäÄ
-!
-linux-train-4.colorado.eduh\äÄ
-
-ceasjira.colorado.eduQaäÄ
-
-dna.colorado.eduL]äÄ
-
-qfadd.colorado.eduYäÄ
-!
-leeds-faculty.colorado.eduCäÄ
-
-stix.colorado.edu!YäÄ
-
-buffportal.colorado.eduÙäÄ
-
-hdsprojects.colorado.eduºäÄ
-%
-beesneeds-upgrade.colorado.edu\äÄ
-
-chuonglab.colorado.educ]äÄ
-
-www.lasp.linkÉäÄ
-
-urquell.colorado.eduÂäÄ
-$
-learningassistantalliance.org\äÄ
-%
-behavioralscience.colorado.eduûCäÄ
-#
-buffportal-spsc.colorado.edu^CäÄ
-
-webtmatest.colorado.edueäÄ
-
-elements.colorado.eduväÄ
-
-tma.colorado.edußäÄ
-
-amath.colorado.edu\äÄ
-
-umc-ems01.colorado.edu#\äÄ
-)
-"bocolatinohistory-dev.colorado.edu\äÄ
-
-themis.colorado.edu»äÄ
-.
-'fossilvertebratesandtraces.colorado.edu\äÄ
-#
-advancedimaging.colorado.edu"]äÄ
-
-psproda1.grcc.eduúòtJ
-
-ccar.colorado.edu	aäÄ
-
-ems.colorado.edu#\äÄ
-
-converge.colorado.edu≈CäÄ
-
-lynda.colorado.edu÷ÄäÄ
-
-colorado.edubÅäÄ
-
-cucontent.colorado.edu \äÄ
-
-ibsweb.colorado.eduâCäÄ
-
-linux.colorado.eduò]äÄ
-
-bro.colorado.eduQ]äÄ
-
-cupc.colorado.edu£CäÄ
-'
- nano-optics-upgrade.colorado.edu\äÄ
-
-mail.cubookstore.comçeäÄ
-!
-ucbsccm-sup02.colorado.eduÿäÄ
-
-yilab.colorado.eduFHäÄ
-
-itll.colorado.eduFaäÄ
-
-extranet.nsidc.org+áäÄ
- 
-emswebclient.colorado.edu#\äÄ
-(
-!www.learningassistantalliance.org\äÄ
-!
-klymkowskylab.colorado.eduFHäÄ
-
-bechtel.colorado.eduIäÄ
-
-casa.colorado.eduëIäÄ
-
-bayes.colorado.eduñ]äÄ
-
-tfea.colorado.edu9YäÄ
-
-libraries.colorado.edu\äÄ
-'
- vivo-cub-setup-test.colorado.eduËäÄ
-!
-biof-trackhub.colorado.eduYäÄ
-
-phet-dev.colorado.eduÅäÄ
-
-storm.colorado.eduIäÄ
-%
-virtuallaboratory.colorado.eduFHäÄ
-
-slhc-web.colorado.edu\äÄ
-
-bit.colorado.eduZ]äÄ
--
-&learningassistantalliance.colorado.edu\äÄ
-"
-lawcollections.colorado.eduìpäÄ
-
-emm-msf-vpn.colorado.edu3ÉäÄ
- 
-law-termkwip.colorado.edu€äÄ
-
-palmerlab.colorado.edus]äÄ
-"
-buffportal.gtm.colorado.eduJÄäÄ
-
-voicethread.colorado.edu2ÄäÄ
- 
-docusigntest.colorado.eduÅäÄ
-
-qualtrics.colorado.edu5ÄäÄ
-
-nascent.colorado.edup]äÄ
-
-cods.colorado.eduaäÄ
-
-colorado.edu4ÅäÄ
-
-phet-api.colorado.eduNÅäÄ
-
-nano-optics.colorado.edu\äÄ
-"
-vivo-cub-setup.colorado.eduËäÄ
-
-rintintin.colorado.edu\äÄ
-
-remote.colorado.eduépäÄ
-
-sparky.colorado.edu¨]äÄ
-
-vaxfirst.colorado.edu
-]äÄ
-&
-external-identikey.colorado.eduyÅäÄ
-
-extranet.nsidc.orgiáäÄ
-
-inside.nsidc.org+áäÄ
-
-bst-db.colorado.eduå\äÄ
-
-bst-serve.colorado.eduà\äÄ
-
-jilafile.colorado.edukäÄ
-#
-buffportal-comp.colorado.eduJÄäÄ
-
-ems1.colorado.edu#\äÄ
-&
-studyabroad-legacy.colorado.edud\äÄ
-
-gtpfeedback.colorado.eduÁäÄ
- 
-kibana.refraction.networkæaäÄ
-"
-cucontent-comp.colorado.edu^ÅäÄ
-
-buffportal.colorado.eduJÄäÄ
-
-phoebe.colorado.eduä\äÄ
-
-identikey.colorado.eduyÅäÄ
-+
-$studyabroad-legacy-test.colorado.edud\äÄ
-#
-buffportal-spsc.colorado.eduJÄäÄ
-
-extranet.nsidc.org+áäÄ
-
-biodatasci.colorado.edu$]äÄ
-!
-mygroups-test.colorado.eduèÅäÄ
-
-playposit.colorado.edu9ÄäÄ
-!
-ucbsccm-sup02.colorado.eduÿäÄ
-
-lasp.colorado.eduÉäÄ
-
-staging.nsidc.org+áäÄ
-
-www-ucb.colorado.edu£ÅäÄ
-
-mail.cubookstore.comçeäÄ
-
-lawdigital.colorado.eduìpäÄ
-
-	nsidc.orgiáäÄ
-"
-identikey-spsc.colorado.eduyÅäÄ
-
-	nsidc.org+áäÄ
- 
-cube-webprod.colorado.eduväÄ
-
-fedauth.colorado.edu∆ÅäÄ
-
-www.colorado.edubÅäÄ
-
-staging.inside.nsidc.orgiáäÄ
-
-pacesproject.orgYàäÄ
-
-k2.colorado.eduiáäÄ
-
-ciresgroups.colorado.eduøàäÄ
-
-qa.nsidc.org+áäÄ
-
-qa.nsidc.org+áäÄ
-
-lasp-auth.colorado.edu"ÉäÄ
-
-cuadmin.colorado.eduCÄäÄ
-!
-tvguide-aniso.colorado.edu≤àäÄ
-
-ccog.colorado.edu«àäÄ
-
-ciscopca.colorado.eduCÄäÄ
-
-remote.colorado.eduépäÄ
-
-www.egy.orgÉäÄ
-"
-ciresmentoring.colorado.edu±àäÄ
-
-inside.nsidc.org+áäÄ
-
-mail.cubookstore.comçeäÄ
-
-staging.inside.nsidc.org+áäÄ
-!
-cucontent.gtm.colorado.edu^ÅäÄ
-
-www-comp.colorado.edubÅäÄ
-
-www.nsidc.orgiáäÄ
-
-integration.nsidc.org+áäÄ
-$
-msf-mars-fw.lasp.colorado.edu3ÉäÄ
-"
-ceasconfluence.colorado.eduRaäÄ
-
-cips.colorado.educmäÄ
-
-www.nsidc.org+áäÄ
-
-mycuhub.colorado.eduÄäÄ
-
-mygroups.colorado.eduéÅäÄ
-"
-cucontent-spsc.colorado.edu^ÅäÄ
-!
-lasp-registry.colorado.eduÉäÄ
-
-cuconnect.colorado.eduíÅäÄ
-
-phet-direct.colorado.edu"ÅäÄ
-
-cires1.colorado.eduàäÄ
-
-ciresblogs.colorado.eduFàäÄ
-
-	nsidc.org+áäÄ
-!
-identikey.gtm.colorado.eduyÅäÄ
-
-phet.colorado.eduÅäÄ
-*
-#external-identikey.gtm.colorado.eduyÅäÄ
-!
-staging.extranet.nsidc.org+áäÄ
-
-ciresgroups.colorado.edu’àäÄ
-
-bioserve.colorado.eduç\äÄ
-
-integration.nsidc.orgiáäÄ
- 
-mygroups.gtm.colorado.eduéÅäÄ
-
-cires.colorado.edu3àäÄ
-"
-identikey-comp.colorado.eduyÅäÄ
-
-lcd-www.colorado.edu≥çäÄ
-
-mycuinfo.colorado.eduóÅäÄ
-
-www.nsidc.org+áäÄ
-
-k2.colorado.edu+áäÄ
-
-	lasp.linkÉäÄ
-!
-staging.extranet.nsidc.org+áäÄ
-
-mycuboulder.colorado.edu9ÅäÄ
-*
-#cires-eo-virtual-tours.colorado.eduXàäÄ
-
-igloo.nsidc.orgiáäÄ
-
-staging.inside.nsidc.org+áäÄ
-
-igacproject.org`àäÄ
-#
-lasp-auth-stage.colorado.edu#ÉäÄ
-
-igloo.nsidc.org+áäÄ
-
-k2.colorado.edu+áäÄ
-
-achieve.colorado.eduK∑äÄ
-
-staging.nsidc.orgiáäÄ
-
-extranet.nsidc.orgiáäÄ
-
-insidethegreenhouse.org‹àäÄ
-
-ciresevents.colorado.edu#àäÄ
-
-igloo.nsidc.org+áäÄ
-
-office365.colorado.edu–ÅäÄ
-
-icacgp-igac2018.org™àäÄ
-
-www.cires.colorado.edu'àäÄ
-
-www-ucb.colorado.edu4ÅäÄ
-
-jilau1.colorado.eduåäÄ
-
-lcd-www.colorado.edu≥çäÄ
-
-fedauth-dev.colorado.edu»ÅäÄ
-
-www.nsidc.orgiáäÄ
-
-	nsidc.orgiáäÄ
-
-thwaitesglacier.orgjàäÄ
-
-ciresgroups.colorado.eduΩàäÄ
-
-solarz.colorado.edu≥çäÄ
-!
-staging.extranet.nsidc.orgiáäÄ
-
-k2.colorado.eduiáäÄ
-
-mecco.colorado.eduÚàäÄ
-
-integration.nsidc.orgiáäÄ
-
-colorado.edu£ÅäÄ
-
-qa.nsidc.orgiáäÄ
-
-staging.nsidc.orgiáäÄ
-!
-sciencepolicy.colorado.eduÎàäÄ
- 
-phet-api-dev.colorado.eduMÅäÄ
-
-jila.colorado.eduåäÄ
-
-lst-gve.colorado.edu∏äÄ
-
-oitcup.colorado.edu‹∑äÄ
-
-cires.colorado.edu'àäÄ
-$
-cewebserver-prod.colorado.eduJ∑äÄ
-
-integration.nsidc.org+áäÄ
-
-solarz.colorado.edu≥çäÄ
-
-staging.nsidc.org+áäÄ
-
-ciresgroups.colorado.eduôàäÄ
-!
-staging.extranet.nsidc.orgiáäÄ
-"
-oitcup-upgrade.colorado.edu‹∑äÄ
-#
-legacy-content1.colorado.edu∏äÄ
- 
-achieve-test.colorado.eduK∑äÄ
-
-lcd-www.colorado.edu≥çäÄ
-
-jilau1.colorado.eduåäÄ
-
-seec.colorado.edu∏äÄ
-
-inside.nsidc.orgiáäÄ
-
-geomag.colorado.eduàäÄ
-
-	buff.link∏äÄ
-%
-test-ecee-jupyter.colorado.edu4∏äÄ
-#
-insideu-staging.colorado.edu∑äÄ
-
-cewebserver.colorado.eduJ∑äÄ
-
-inside.nsidc.orgiáäÄ
-
-ciresgroups.colorado.eduàäÄ
-
-cires.colorado.eduàäÄ
-
-solarz.colorado.edu≥çäÄ
-
-riverware.org∏äÄ
-
-isgw-forum.colorado.edu	ãäÄ
-
-jabber.colorado.edud∏äÄ
-
-alertus.colorado.edu∏äÄ
-
-numberscope.colorado.eduñäÄ
-
-sci.colorado.edu∑äÄ
-
-huey.colorado.eduè∑äÄ
-
-lcd.colorado.edu≥çäÄ
-
-www.cires.colorado.edu3àäÄ
-
-aahvrc.colorado.edu∏äÄ
-
-qa.nsidc.orgiáäÄ
-
-solarz.colorado.edu≥çäÄ
-
-cmci.colorado.edu)∏äÄ
-
-co-lsen.colorado.eduÛàäÄ
-
-cucontent.colorado.edu∏äÄ
-
-lcd.colorado.edu≥çäÄ
-
-ucb-alertus.colorado.edu∏äÄ
-
-earthlab.colorado.edu°àäÄ
-#
-lst-fusion-sand.colorado.edu#∏äÄ
-#
-lawlegacy-dev01.colorado.edu∑äÄ
-
-jilau1.colorado.eduåäÄ
-
-breeze.colorado.edu∏äÄ
-
-insidecires.colorado.eduBàäÄ
-&
-droughtindexportal.colorado.eduªàäÄ
-
-jabber.colorado.edud∏äÄ
-!
-lawinnovation.colorado.edu∏äÄ
-
-zabbix.cs.colorado.edu∏äÄ
-
-tmilab.colorado.eduïäÄ
-
-ofa-web01.colorado.edu∞∏äÄ
-
-lcd-www.colorado.edu≥çäÄ
-
-law-web.colorado.edu∏äÄ
-
-crown-web1.colorado.edu∑äÄ
-
-igloo.nsidc.orgiáäÄ
-
-ciresgroups.colorado.eduqàäÄ
-
-statgen.colorado.eduãäÄ
-
-exp-c.int.colorado.edud∏äÄ
-
-jilau1.colorado.eduåäÄ
-"
-reg-docint-dev.colorado.eduV∏äÄ
-
-exp-c.int.colorado.edud∏äÄ
-
-cmciserver1.colorado.edu)∏äÄ
-
-lcd.colorado.edu≥çäÄ
-
-lawlegacy.colorado.edu∑äÄ
-#
-test-lawlibrary.colorado.edu∑äÄ
-
-int.colorado.edud∏äÄ
-
-www.riverware.org∏äÄ
-"
-physicscourses.colorado.edu7∏äÄ
-
-regina.colorado.eduT∏äÄ
-
-jilau1.colorado.eduåäÄ
-
-ofa.colorado.edu∞∏äÄ
-
-cuexpress.colorado.edud∏äÄ
-
-bouldersolarreu.comª∏äÄ
-
-secs.oakland.edu“ç
-
-igp.colorado.edu1†äÄ
-'
- reg-docinternal-dev.colorado.eduV∏äÄ
-
-oakland.eduT“ç
-$
-cubouldersurplus.colorado.eduE∏äÄ
-
-exp-e.int.colorado.edud∏äÄ
-
-oakland.edu“ç
-
-lcd.colorado.edu≥çäÄ
-
-colorado.edud∏äÄ
-
-solarz.colorado.edu≥çäÄ
-
-cuexpress.colorado.edud∏äÄ
-
-ciresgroups.colorado.eduõàäÄ
-
-ofainternal.colorado.edu∞∏äÄ
- 
-trailsparrow.colorado.edu3òäÄ
-
-career-web.colorado.eduØ∏äÄ
-
-int.colorado.edud∏äÄ
-
-oakland.eduY“ç
-
-lcd.colorado.edu≥çäÄ
-
-studentjobs.colorado.edu∞∏äÄ
-
-ip.kaptivo.liveM´—ç
-
-galaxy.phy.cmich.edu1§—ç
-
-oakland.edu&“ç
-
-morse.colorado.eduJ∏äÄ
-
-oakland.edu|“ç
-
-int.colorado.edud∏äÄ
-
-colorado.edud∏äÄ
-
-exp-e.int.colorado.edud∏äÄ
-
-aac.colorado.eduØ∏äÄ
-!
-reg-webarch01.colorado.eduU∏äÄ
-
-umflint.edupÿç
-
-insideu.colorado.edu∑äÄ
-
-oakland.eduN“ç
-
-cms.cmich.edu£—ç
-
-tlstest.vpnalyzer.comÇ{‘ç
- 
-ecee-jupyter.colorado.edu4∏äÄ
-
-daxlab.colorado.edu"“äÄ
-
-labanywhere.umflint.edu/
-ÿç
-
-oakland.edu“ç
-
-jabber.colorado.edud∏äÄ
-
-oakland.eduÿ“ç
-
-cs-zabbix.colorado.edu∏äÄ
-
-marge.colorado.eduu·äÄ
-
-umflint.edulÿç
-
-cuexpress.colorado.edud∏äÄ
-
-exp-e.int.colorado.edud∏äÄ
-
-oakland.eduI“ç
-
-oakland.edup“ç
-
-umflint.edu»ÿç
-
-sm-pub.cmich.edu©—ç
-
-reg-docint.colorado.eduT∏äÄ
-!
-botanydb-test.colorado.eduÖƒäÄ
-
-	cmich.edu§—ç
-#
-reg-docinternal.colorado.eduT∏äÄ
-
-lawlibrary.colorado.edu∑äÄ
-
-reg.colorado.eduT∏äÄ
-
-ucb-direct.colorado.eduæ∏äÄ
-
-greatlakeswetlands.org≥Ø—ç
-#
-its-targaryen-da.umflint.edu,
-ÿç
-
-	cmich.edu©—ç
-
-arcgis-db.umflint.edu
-ÿç
-
-oakland.eduU“ç
-!
-daxlab-imac20.colorado.edu"“äÄ
-
-loc.vpnalyzer.netŸ{‘ç
-#
-catalog-archive.colorado.eduU∏äÄ
-
-oakland.edul“ç
-
-sunapsis4.umflint.edu'
-ÿç
-
-Expressway-E-1.cmich.edu§—ç
-
-pitserver.colorado.eduƒäÄ
-
-	cmich.edu©—ç
-
-view7-gw1.umflint.edub
-ÿç
-
-tlstest.vpnalyzer.comÖ{‘ç
-#
-cuservices-prod.colorado.eduL∏äÄ
-
-oakland.edu“ç
-
-fluid.colorado.eduÔäÄ
-
-oakland.edu““ç
-
-view7-br2.umflint.edu/
-ÿç
-
-umflint.edumÿç
-
-view7-comp.umflint.edu/
-ÿç
-
-view7-gw1.umflint.edu/
-ÿç
-
-oakland.edum“ç
-
-jabber-guest.cmich.edu§—ç
-
-oakland.eduZ“ç
-
-kelp.colorado.edu"“äÄ
-#
-sam-downloads01.colorado.eduL∏äÄ
-
-oakland.eduu“ç
-
-cuservices.colorado.eduL∏äÄ
-
-tlstest.vpnalyzer.comÉ{‘ç
-
-cms.cmich.edu§—ç
-
-umflint.eduÿç
-
-oakland.edu{“ç
-
-oakland.eduq“ç
-
-botanydb.colorado.eduÖƒäÄ
-
-oakland.eduÿ“ç
-
-psr.vpnalyzer.com„{‘ç
-#
-its-targaryen-da.umflint.edu-
-ÿç
-
-masala.colorado.edu∫äÄ
-
-oakland.edu>»“ç
-
-sm-pub.cmich.edu©—ç
-
-	cmich.edu©—ç
-
-exp-c.int.colorado.edud∏äÄ
-
-ia-lab.colorado.eduu·äÄ
-
-suda.colorado.edu„äÄ
-
-oakland.edu‘“ç
-
-oakland.edu˝“ç
-
-se.cmich.eduÜØ—ç
-
-psr.vpnalyzer.comÂ{‘ç
-
-oakland.edu“ç
-
-www.bouldersolarreu.comª∏äÄ
-
-tlstest.vpnalyzer.comÅ{‘ç
-
-loc.vpnalyzer.netÿ{‘ç
-
-psr.vpnalyzer.comÊ{‘ç
-
-jabber-guest.cmich.edu£—ç
-
-view7-br2.umflint.edu/
-ÿç
-
-oakland.eduM“ç
-
-tlstest.vpnalyzer.com~{‘ç
-
-psr.vpnalyzer.comÁ{‘ç
-
-sm-pub.cmich.edu©—ç
-
-labanywhere.umflint.edu/
-ÿç
-
-view7-gw2.umflint.edu/
-ÿç
-
-Expressway-E-1.cmich.edu£—ç
-
-sunapsis.umflint.edu'
-ÿç
-
-view7-gw1.umflint.edu/
-ÿç
-
-view7-br1.umflint.edu/
-ÿç
-
-view7-db.umflint.edu/
-ÿç
-
-cucfl2.umflint.edu»ÿç
-
-bor.colorado.edu*÷äÄ
-
-view7-int2.umflint.edu/
-ÿç
-
-psr.vpnalyzer.comÍ{‘ç
-
-view7-br1.umflint.edu/
-ÿç
-
-oakland.edu“ç
-
-viewgw.umflint.edub
-ÿç
-
-viewlb.umflint.edub
-ÿç
-
-labanywhere.umflint.edub
-ÿç
-
-loc.vpnalyzer.net◊{‘ç
-
-loc.vpnalyzer.net›{‘ç
-
-oakland.edu`“ç
-
-www.sm-pub.cmich.edu©—ç
-
-view7-gw1.umflint.edub
-ÿç
-
-view7-comp.umflint.edub
-ÿç
-
-	wayne.edu Ÿç
-
-its-ems.umflint.eduh
-ÿç
-
-meow.vpnalyzer.com2{‘ç
-
-loc.vpnalyzer.netﬂ{‘ç
-
-viewlb.umflint.edu/
-ÿç
-
-view7-comp.umflint.edu/
-ÿç
-
-view7-int1.umflint.edub
-ÿç
-
-view7-int2.umflint.edu/
-ÿç
-
-oakland.edu÷“ç
-
-psr.vpnalyzer.com‚{‘ç
-
-arcgis-web.umflint.eduJ
-ÿç
-)
-"assessments.clust.secs.oakland.eduÖ“ç
-
-labanywhere.umflint.educ
-ÿç
-
-secs.oakland.edu]“ç
-
-view7-int1.umflint.edu/
-ÿç
-
-secs.oakland.edu|“ç
-
-flintmap.umflint.eduJ
-ÿç
-
-view7-db.umflint.edu/
-ÿç
-
-viewlb.umflint.edu/
-ÿç
-
-psyclinicti.ad.wayne.edu Ÿç
-
-	wayne.eduK Ÿç
-
-viewgw.umflint.edub
-ÿç
-
-	wayne.edu†Ÿç
-
-view7-gw2.umflint.edub
-ÿç
-
-view7-gw2.umflint.edub
-ÿç
-
-view7-br2.umflint.edub
-ÿç
-
-view7-int2.umflint.educ
-ÿç
-
-csm.wayne.eduŸç
-
-view7-db.umflint.edub
-ÿç
-
-viewgw.umflint.edu/
-ÿç
-
-prod.wayne.edu< Ÿç
-
-tlstest.vpnalyzer.comÄ{‘ç
-
-view7-br2.umflint.educ
-ÿç
-
-view7-gw1.umflint.educ
-ÿç
-
-view7-int1.umflint.edu/
-ÿç
-
-view7-int1.umflint.educ
-ÿç
-
-	cmich.edu£—ç
-
-apps.wayne.edu¥Ÿç
-
-view7-int1.umflint.edub
-ÿç
-
-viewlb.umflint.educ
-ÿç
-
-viewgw.umflint.educ
-ÿç
-
-view7-int1.umflint.educ
-ÿç
-
-umflint.eduKNÿç
-
-git.wayne.edu¢ Ÿç
-
-view7-br1.umflint.edub
-ÿç
-
-degreeworks.wayne.edu¶ Ÿç
-
-view7-gw1.umflint.educ
-ÿç
-
-viewmgr.umflint.educ
-ÿç
-
-viewmgr.umflint.edu/
-ÿç
-
-mapflint.umflint.eduJ
-ÿç
-
-www.vlab.vdi.wayne.edu9Ÿç
-
-loc.vpnalyzer.net‡{‘ç
-
-view7-comp.umflint.educ
-ÿç
-
-view7-gw2.umflint.educ
-ÿç
-
-webmail.wayne.eduK Ÿç
-
-viewmgr.umflint.edu/
-ÿç
-
-view7-db.umflint.educ
-ÿç
-
-viewgw.umflint.educ
-ÿç
-
-viewmgr.umflint.educ
-ÿç
-
-dgwpapp1.prod.wayne.edu¶ Ÿç
-
-web4prod.wayne.edu∆Ÿç
-$
-acquisition.library.wayne.eduèŸç
-
-view7-br1.umflint.educ
-ÿç
-
-view7-int2.umflint.educ
-ÿç
-
-view7-br1.umflint.educ
-ÿç
-#
-www.psyclinicti.ad.wayne.edu Ÿç
-
-labanywhere.umflint.educ
-ÿç
-
-view7-comp.umflint.educ
-ÿç
-
-apps.wayne.edu4Ÿç
-
-viewlb.umflint.edub
-ÿç
-
-	wayne.eduK Ÿç
-
-view7-br1.umflint.edub
-ÿç
-
-viewgw.umflint.edu/
-ÿç
-
-view7-comp.umflint.edub
-ÿç
-
-view7-br2.umflint.edub
-ÿç
-
-view7-int2.umflint.edub
-ÿç
-
-ssomgr.prod.wayne.eduÀŸç
-
-svn.wayne.edu•Ÿç
-
-view7-int2.umflint.edub
-ÿç
-
-view7-gw2.umflint.edu/
-ÿç
-*
-#www.researchtraining.ovpr.wayne.eduŸç
-
-www.research2.wayne.edu0Ÿç
-
-webmail.wayne.eduK Ÿç
-
-view7-db.umflint.educ
-ÿç
-
-labanywhere.umflint.edub
-ÿç
-
-vlab.vdi.wayne.edu9Ÿç
-
-view7-br2.umflint.educ
-ÿç
-
-www.elahi.wayne.eduôŸç
-
-cc.wayne.eduñ Ÿç
-
-www.vlab.vdi.wayne.edu9Ÿç
-
-view7-gw2.umflint.educ
-ÿç
-
-banwkfp1.prod.wayne.edu…Ÿç
-
-viewlb.umflint.educ
-ÿç
-
-www.research2.wayne.edu/Ÿç
-
-www.lib3.lib.wayne.eduËŸç
-
-online.oiss.wayne.eduPŸç
-$
-quicksearch.library.wayne.edu˙Ÿç
-
-dlxs.library.wayne.edu¿Ÿç
-!
-projects.library.wayne.edu~Ÿç
-
-viewmgr.umflint.edub
-ÿç
-
-luna.library.wayne.edu¿Ÿç
-#
-facilities.library.wayne.edu~Ÿç
-
-ods.wayne.edu∆Ÿç
-
-idp.wmich.edu.⁄ç
-
-gowmu.wmich.edu2⁄ç
-"
-dashboard.library.wayne.eduèŸç
-
-vega2.library.wayne.edu˙Ÿç
-"
-dashboard.library.wayne.edu¿Ÿç
-
-research2.wayne.edu0Ÿç
-
-	wayne.edu› Ÿç
-
-banssbp1.prod.wayne.edu∆Ÿç
- 
-digital.library.wayne.edu¿Ÿç
-
-	wayne.eduêŸç
- 
-www.online.oiss.wayne.eduPŸç
-
-dgwpapp1.prod.wayne.edu¶ Ÿç
-
-	wayne.eduv Ÿç
-
-med.wayne.eduxŸç
-
-viewmgr.umflint.edub
-ÿç
-!
-projects.library.wayne.edu¿Ÿç
-
-www.csm.wayne.eduŸç
-#
-www.literaryworlds.wmich.edury⁄ç
-
-	wayne.edu…Ÿç
-!
-www.projects.lib.wayne.edu-¨Ÿç
-
-wfts1.wmupd.wmich.eduJ⁄ç
-
-support.wmich.edu"™⁄ç
-
-	wayne.eduú Ÿç
-
-luna.library.wayne.edu~Ÿç
-$
-literaryworlds.coas.wmich.edury⁄ç
-&
-archivematica.library.wayne.edu˙Ÿç
- 
-digital.library.wayne.edu~Ÿç
-
-	wayne.eduÀŸç
-
-lib3.lib.wayne.eduËŸç
-
-degreeworks.wayne.edu¶ Ÿç
- 
-combine.library.wayne.edu¿Ÿç
-%
-neefreservations.lib.wayne.eduﬁŸç
-
-med.wayne.eduâŸç
-
-dlxs.library.wayne.edu~Ÿç
-
-courseval.umflint.edutÿç
-
-research2.wayne.edu/Ÿç
- 
-www.rs4.reuther.wayne.eduBpŸç
-
-research2.wayne.edu0Ÿç
-
-clearpass.tc.mtu.eduÀ@€ç
-
-funds.library.wayne.edu¿Ÿç
-
-www.reuther.wayne.eduÁŸç
-
-dgwpapp1.prod.wayne.edu¶ Ÿç
-)
-"www.neefreservations.lib.wayne.eduﬁŸç
-#
-facilities.library.wayne.edu¿Ÿç
-$
-acquisition.library.wayne.edu¿Ÿç
-
-www.research2.wayne.edu0Ÿç
- 
-digital.library.wayne.eduèŸç
-
-workflow.wayne.edu…Ÿç
-
-primavera.mtu.edu=D€ç
-
-elahi.wayne.eduôŸç
-
-www.wmich.eduK⁄ç
-"
-elib7apps.library.wayne.edu˙Ÿç
-
-www.rovernet.mtu.edu.D€ç
-
-degreeworks.wayne.edu¶ Ÿç
-
-vega3.library.wayne.edu˙Ÿç
-
-wfts0.wmupd.wmich.eduH⁄ç
-
-govpn.wmich.edu˝⁄ç
-$
-datacatalog.library.wayne.edu~Ÿç
-
-vega1.library.wayne.edu˙Ÿç
-
-dcatstest.med.wayne.eduàŸç
-
-www.sais.wmich.edu—⁄ç
-
-crsconcore.med.wayne.eduÖŸç
-
-pilot.ceas.wmich.eduå⁄ç
-$
-datacatalog.library.wayne.eduèŸç
-"
-www.ksdevweb.ovpr.wayne.eduãŸç
-
-coeusreports.wayne.edu#Ÿç
-
-www.sm-pub.cmich.edu©—ç
-
-mediasite.wmich.edu*⁄ç
- 
-clearpass-test.tc.mtu.edu)D€ç
- 
-combine.library.wayne.edu~Ÿç
-
-alertus.wmupd.wmich.eduE⁄ç
-
-hms.reslife.wmich.edu⁄⁄ç
-
-esrs.wmich.eduP[⁄ç
-
-redirect.wmich.eduJ⁄ç
-
-reuther.wayne.eduÁŸç
-
-brn227.brown.wmich.edury⁄ç
-
-assets.ceas.wmich.edu°ë⁄ç
-
-funds.library.wayne.eduèŸç
-$
-datacatalog.library.wayne.edu¿Ÿç
-$
-acquisition.library.wayne.edu~Ÿç
-
-esem.wmich.eduI⁄ç
- 
-combine.library.wayne.eduèŸç
-
-status-test.it.mtu.eduí@€ç
-!
-www.coeusreports.wayne.edu#Ÿç
-
-webauth.wmich.edu±⁄ç
-#
-facilities.library.wayne.eduèŸç
-
-repos.ceas.wmich.edu¸ê⁄ç
-!
-projects.library.wayne.eduèŸç
- 
-dcatsoncore.med.wayne.eduÖŸç
-
-rovernet.mtu.edu.D€ç
-
-slimjim.it.wmich.edu˚⁄ç
-
-elevate.wmich.edu û⁄ç
-
-www.esrs.wmich.eduP[⁄ç
-
-sso.mtu.eduMD€ç
-
-	wmich.eduK⁄ç
-
-clubsecrets.cs.wmich.eduPè⁄ç
-#
-publishing.library.wayne.edu˙Ÿç
-
-rs4.reuther.wayne.eduBpŸç
-
-library.wmich.eduÖ⁄ç
-
-login.library.wayne.edu˙Ÿç
-&
-researchtraining.ovpr.wayne.eduŸç
- 
-reuther.library.wayne.edu˙Ÿç
-
-www.idm-prod.mtu.eduLD€ç
-
-idp.test.wmich.eduí⁄ç
-
-clearpass03.tc.mtu.eduÀ@€ç
-
-support.it.mtu.eduQD€ç
-
-wdet.org<Ÿç
-
-print.mtu.edu[D€ç
-
-www.print.mtu.edu[D€ç
-
-www.resnet.mtu.edu-D€ç
-
-rpt.sais.wmich.edu”⁄ç
-
-photo.wmupd.wmich.eduN⁄ç
-
-bell.ceas.wmich.eduπå⁄ç
-
-www.idm.mtu.eduLD€ç
-!
-libproxy.library.wmich.eduà⁄ç
-
-crsctest.med.wayne.eduàŸç
-
-resnet.mtu.edu-D€ç
-$
-literaryworlds.coas.wmich.edury⁄ç
-
-fm.wmich.edu–∂⁄ç
-
-print.mtu.edu[D€ç
-
-idm.mtu.eduLD€ç
-
-clearpass01.tc.mtu.edu…@€ç
-
-sais.wmich.edu—⁄ç
-
-mymichigantech.mtu.edubD€ç
- 
-elib7db.library.wayne.edu˙Ÿç
-
-printing.mtu.educD€ç
-
-redirect.it.mtu.eduœD€ç
-
-govpn.test.wmich.edu˝⁄ç
-
-wiki.ceas.wmich.eduÉë⁄ç
-
-pki-aia.it.mtu.eduJD€ç
- 
-services-test.lib.mtu.eduPD€ç
-
-groups.it.mtu.eduPF€ç
-
-aspire-dev.cs.mtu.eduxD€ç
-
-raolab.biomed.mtu.eduID€ç
-!
-www.mymichigantech.mtu.edubD€ç
-
-www.parentnet.mtu.eduªF€ç
-!
-www.mymichigantech.mtu.edubD€ç
-!
-www.mymichigantech.mtu.edubD€ç
-
-housing.mtu.eduÎD€ç
-
-print.mtu.edu[D€ç
-
-mymichigantech.mtu.edubD€ç
-
-www.print.mtu.edu[D€ç
-
-bdwdbp.cc.wmich.edu¥⁄ç
-$
-literaryworlds.coas.wmich.edury⁄ç
-
-www.printing.mtu.educD€ç
-
-fm.wmich.eduË∂⁄ç
-
-redmine.ceas.wmich.eduoé⁄ç
-
-wmudps.wmich.eduG⁄ç
- 
-rail-learning-new.mtu.edu3D€ç
-
-huskycast.mtu.eduªG€ç
-
-vpn.wmupd.wmich.edu(T⁄ç
-
-bssp3.cc.wmich.edu6¥⁄ç
-#
-www.literaryworlds.wmich.edury⁄ç
-
-	m.mtu.edueD€ç
-
-superiorideas.orgfD€ç
-
-tutor.cs.mtu.edunD€ç
-
-deptspanel2.it.mtu.eduPE€ç
-
-mirrorforms.it.mtu.eduÚD€ç
-
-clospanel.it.mtu.eduD€ç
-
-deptspanel2.it.mtu.eduPE€ç
-
-www.mylogin.mtu.eduND€ç
-
-login.mtu.eduUF€ç
-
-clospanel.it.mtu.eduD€ç
-
-www.print.mtu.edu[D€ç
-
-www.courses.mtu.edueF€ç
-
-huskieslive.mtu.eduWF€ç
-
-blackhawk.ceas.wmich.edu–å⁄ç
-
-huskymail.mtu.edu!F€ç
-
-emsweb.mtu.eduvF€ç
-
-banforms.it.mtu.eduˇD€ç
-
-lostbot.it.mtu.eduˆG€ç
-%
-www.rail-learning-test.mtu.edu9E€ç
-
-www.banbuck.mtu.eduNF€ç
-
-idm-prod.mtu.eduLD€ç
-
-jira-test.it.mtu.eduF€ç
-
-www.email.mtu.edu"F€ç
-
-www.mindtrekkers.mtu.eduÓF€ç
-
-www.emsweb.mtu.eduvF€ç
-
-mymichigantech.mtu.edubD€ç
-
-buckforms.it.mtu.eduvD€ç
-
-water.cs.mtu.edu>F€ç
-'
- www.mymichigantechmirror.mtu.eduF€ç
-
-cshci-dev.mtu.eduF€ç
-
-mtu.eduuF€ç
-
-webta.cs.mtu.eduhD€ç
-
-mylogin.mtu.eduND€ç
-
-www.printing.mtu.educD€ç
-
-www.wmudps.wmich.eduG⁄ç
-
-cchi.mtu.edu{D€ç
-
-google-reset.ascl.netjD€ç
-
-appsanywhere-adm.mtu.eduF€ç
-
-parentnet.mtu.eduªF€ç
-$
-bridge.newapple.trans.mtu.edu‡G€ç
-
-zabbix-prod.it.mtu.edu\F€ç
-$
-libproxydev.library.wmich.edus⁄ç
-
-amp.tc.mtu.eduÛD€ç
-
-deptspanel2.it.mtu.eduPE€ç
-
-
-tc.mtu.edu’G€ç
-
-math.mtu.eduÊD€ç
-
-groups.it.mtu.eduPF€ç
-
-pki-aia-test.it.mtu.edu|D€ç
-
-groups.it.mtu.eduPF€ç
-
-cshwsubmit.cs.mtu.eduoD€ç
- 
-www.rail-learning.mtu.edu5E€ç
-
-merl.michiganltap.org‡G€ç
-
-secure.mtu.edutF€ç
-
-pages.mtu.eduËF€ç
-
-www.amp.tc.mtu.eduÛD€ç
-
-www.housing.mtu.eduÎD€ç
-
-keypath.courses.mtu.eduÂD€ç
-
-newapple.trans.mtu.edu‡G€ç
-&
-roadsoft.newapple.trans.mtu.edu‡G€ç
-
-www.superiorideas.orgfD€ç
-
-clospanel.it.mtu.eduD€ç
-
-shinyclass.ffr.mtu.edu=F€ç
-
-cshci.cs.mtu.eduG€ç
-
-www.email.mtu.edu#F€ç
-$
-www.wherethehellwasigoing.com´´€ç
-
-www.huskycast.mtu.eduªG€ç
-
-groups.it.mtu.eduPF€ç
-!
-rail-learning-test.mtu.edu9E€ç
-
-www.login.mtu.eduUF€ç
-
-banweb.mtu.eduèF€ç
-
-	gleic.org‡G€ç
-
-mtupg.mtu.edu≠F€ç
-
-michiganltap.org‡G€ç
-
-www.huskieslive.mtu.eduWF€ç
-
-www.mtupg.mtu.edu≠F€ç
-
-huskymail.mtu.edu F€ç
-
-www.login.mtu.eduUF€ç
-
-web.prod.trans.mtu.eduÁD€ç
-
-email.mtu.edu#F€ç
-
-PORTAL1-GEO.SABU.MTU.EDUŸ´€ç
-
-crafty.lugmtu.orgº€ç
-
-email.mtu.edu"F€ç
-!
-www.web.prod.trans.mtu.eduÁD€ç
-
-www.security.mtu.eduÏG€ç
-
-vpn.mtri.org<j€ç
-
-techtracs.it.mtu.edu@G€ç
-
-www.blossom.ffr.mtu.eduµF€ç
-
-deptspanel2.it.mtu.eduPE€ç
-
-nb.it.mtu.edu=G€ç
-
-www.tc.mtu.edu’G€ç
-
-hpc.mtu.edu¬D€ç
-
-www.pages.mtu.eduËF€ç
-
-www.roadsoft.org‡G€ç
-
-collab.sfi.mtu.edu7F€ç
-
-portal1-geo.sabu.mtu.eduŸ´€ç
-
-www.gleic.org‡G€ç
- 
-www.andrewsstudybible.com œè
-
-
-it.mtu.eduaF€ç
-
-hometracker.cs.mtu.edu?F€ç
-
-vpn.wmtu.mtu.edu
-j€ç
-#
-mymichigantechmirror.mtu.eduF€ç
-
-deptspanel2.it.mtu.eduPE€ç
-"
-ltap.newapple.trans.mtu.edu‡G€ç
-
-banbuck.mtu.eduNF€ç
-"
-www.keypath.courses.mtu.eduÂD€ç
-
-nb2.it.mtu.edu=E€ç
-
-www.secure.mtu.edutF€ç
-
-mindtrekkers.mtu.eduÓF€ç
-
-www.it.mtu.eduaF€ç
-
-login.mtu.eduUF€ç
-
-netdrms01.nispdc.nso.eduxí
-
-techpay.mtu.edu´F€ç
-
-www.syp.mtu.edu•G€ç
-
-portal1-geo.sabu.mtu.eduŸ´€ç
-
-www.techpay.mtu.edu´F€ç
-
-docker.lugmtu.orgº€ç
-
-roadsoft.us‡G€ç
-
-emailinfo.mtu.edu™F€ç
-
-myloan.gvsu.edu=î
-
-techshop.mtu.edu®F€ç
-
-vpn.mtu.eduj€ç
- 
-www.merl.michiganltap.org‡G€ç
- 
-wherethehellwasigoing.com´´€ç
-
-events.mtu.edu:F€ç
-
-exchange.andrews.eduóœè
-
-www.roadsoft.us‡G€ç
-
-roadsoft.org‡G€ç
-
-www.emailinfo.mtu.edu™F€ç
-
-cock.lugmtu.orgº€ç
-
-www.huskymail.mtu.edu!F€ç
-
-andrews.eduœè
-
-construct.eecn.mtu.edu1M€ç
-
-courses.mtu.edueF€ç
-
-learningcenters.mtu.edu¥F€ç
-
-nciprelay.lib.mtu.edu∫F€ç
-
-www.techshop.mtu.edu®F€ç
-
-raffle-snat.it.mtu.edu!M€ç
-
-ulysses.calvin.edu
-éjô
-
-panorama.calvin.edu©jô
-
-ctt.mtu.edu‡G€ç
-
-www.emsweb-test.mtu.edulF€ç
-
-www.hymnary.orgájô
-
-andrews.eduñœè
-
-
-nb.mtu.edu=G€ç
-
-vault.cs.mtu.edu/T€ç
-&
-www.loadrating.michiganltap.org‡G€ç
-
-techshop-test.mtu.edu∏F€ç
-
-vso.nso.edu{í
-
-
-calvin.edu-»jô
-
-portal1-geo.sabu.mtu.eduŸ´€ç
-
-theia.cs.calvin.edutjô
-
-www.csa.mtu.eduKG€ç
-
-emsweb-test.mtu.edulF€ç
-
-www.construction.mtu.edu1M€ç
-
-winlab.gvsu.edu=î
- 
-www.andrewsstudybible.org œè
-
-apps.mtu.educF€ç
-
-s2admin.calvin.edu0»jô
-
-
-calvin.edu<»jô
-$
-www.cardservices-test.mtu.eduOG€ç
-
-calvinseminary.eduâjô
-
-staff.gvsu.eduê=î
-
-
-calvin.eduø|jô
-
-security.mtu.eduÏG€ç
-
-www.bandevel.mtu.edu_F€ç
-
-mirrors.lug.mtu.eduº€ç
-
-www.ctt.mtu.edu‡G€ç
-
-
-lugmtu.orgº€ç
- 
-www.techshop-test.mtu.edu∏F€ç
-
-andrews.eduñœè
-
-www.techfinder.mtu.edu@G€ç
-
-syp.mtu.edu•G€ç
-
-nispdc.nso.edu=í
-
-exchange.andrews.eduóœè
-
-pa-5220-2.calvin.edu©jô
-
-andrewsstudybible.com œè
-
-nispdc.nso.edu>í
-
-7days.lugmtu.orgº€ç
-
-groups.it.mtu.eduPF€ç
-
-vpn-test.gvsu.eduÖ=î
-
-www.www2.gvsu.eduÇ=î
-
-
-calvin.edu
-Œjô
-
-cherwell.calvin.eduÀjô
-
-s2admin.calvin.edu-»jô
-
-andrews.edu%œè
-
-	delta.edu1ÅÖ°
-
-downloads.it.mtu.eduPG€ç
-
-idphotos.calvin.eduê»jô
-
-construction.mtu.edu1M€ç
-
-www.facweb.gvsu.eduê=î
-!
-filemakerserver.albion.eduz|ì
-
-
-calvin.edu©jô
-
-www.michiganltap.org‡G€ç
-
-andrews.eduóœè
-
-fixablelife.orgÀœè
-
-wcbord-web.calvin.edu<»jô
-
-training.gvsu.eduê=î
-
-pa-vpn-2.calvin.edu©jô
-
-rt.albion.eduF|ì
-
-whammies.calvin.eduÁ|jô
-
-www.training.gvsu.eduê=î
-
-faculty.gvsu.eduê=î
-
-
-calvin.eduÀjô
-
-exchange.andrews.eduñœè
-
-nso.edu~í
-
-iot.cs.calvin.edu√jô
-"
-loadrating.michiganltap.org‡G€ç
-
-www.fixablelife.orgÀœè
-
-nso.virtualsolar.org{í
-
-sam.it.mtu.eduıG€ç
- 
-construction.eecn.mtu.edu1M€ç
-
-www.calvin.eduî»jô
-
-facweb.gvsu.eduê=î
-
-uphill.calvin.eduî»jô
-
-jobedevkey.calvin.eduU˝jô
-"
-EX2-2019.inside.andrews.eduóœè
-"
-merl.newapple.trans.mtu.edu‡G€ç
-
-
-calvin.edu
-éjô
-
-pa-5220-1.calvin.edu©jô
-
-clack.calvin.edu
-Œjô
-
-exchange.andrews.eduñœè
-
-borg-webmo.calvin.edun¬jô
-
-pa-5220-2.calvin.edu©jô
-
-docs.virtualsolar.orgxí
-
-app.calvin.eduê»jô
-
-PORTAL1-GEO.SABU.MTU.EDUŸ´€ç
-$
-jedha-test.calvinseminary.edu*âjô
-
-origin2.internet2.edu$˝£
- 
-populi.calvinseminary.edu*âjô
-
-	emich.eduûL§
-
-PORTAL1-GEO.SABU.MTU.EDUŸ´€ç
-
-andrews.eduóœè
-
-msfc.virtualsolar.org{í
-
-vpn-pek.it.mtu.eduj€ç
-
-pa-5220-1.calvin.edu©jô
-
-www.staff.gvsu.eduê=î
-
-
-calvin.eduî»jô
-
-
-calvin.eduê»jô
-
-www2.gvsu.eduÇ=î
-
-cpscadmin.cs.calvin.edu√jô
-
-	emich.edurL§
-
-cherwellmapp.calvin.eduÀjô
-
-emsweb.calvin.eduÁ|jô
-
-jobedev.calvin.eduU˝jô
-"
-EX1-2019.inside.andrews.eduñœè
-
-omd-msu.aglt2.org'Ï)¿
-
-nispdc.nso.eduEí
-
-uturn.calvin.eduéjô
-
-nso.eduií
-
-cherwelldemo.calvin.eduÀjô
-
-origin.internet2.edu$˝£
-
-cartalk.calvin.edu
-Œjô
-
-	emich.eduûL§
-
-pa-vpn-1.calvin.edu©jô
-
-www.learnpdc.orgT˝jô
-
-alma.edu.˙e¿
-
-alma.edu.˙e¿
-
-netdrms02.nispdc.nso.edu{í
-
-pa-5220-2.calvin.edu©jô
-
-brooks.cs.calvin.edu√jô
-
-	emich.edu1ûL§
-
-radiologypacs.dmc.org»ºãõ
-
-www.faculty.gvsu.eduê=î
-
-	emich.edu{ûL§
-
-andrews.eduœè
-
-alma.edu.˙e¿
-
-
-calvin.eduÁ|jô
-
-andrews.eduñœè
-
-ezproxy.emich.edu7L§
-
-borg.calvin.eduD¬jô
-
-iot.cs.calvin.edu√jô
-
-adfs.calvin.edu»jô
-
-www.apps.baker.edu⁄Pû
-
-alma.edu[˙e¿
-
-	emich.edujûL§
-
-	delta.eduLÖ°
-
-	emich.eduQûL§
-
-lists.incommon.org$˝£
-
-origin2.internet2.edu$˝£
-
-adfs.calvin.edu»jô
-
-aquinas.eduú\¿
-
-	delta.edusÅÖ°
-
-click.calvin.edu
-Œjô
-
-	delta.eduÅÖ°
-
-	delta.eduûÅÖ°
-
-	emich.edu¥ûL§
-
-	delta.eduòÅÖ°
-
-	delta.eduùÅÖ°
-
-andrews.eduóœè
-
-	emich.edubûL§
-
-aquinas.edu3\¿
-
-alma.edu.˙e¿
- 
-www.radiologypacs.dmc.org»ºãõ
-#
-psconfig.opensciencegrid.orgiÏ)¿
-
-ezproxy.delta.edunÅÖ°
-
-	emich.eduêL§
-
-synology.delta.edusÅÖ°
-
-	emich.eduûL§
-
-hymnary.orgájô
-
-
-calvin.edu»jô
-
-origin1.internet2.edu$˝£
-
-pdcbook.calvin.eduT˝jô
-
-fluxqc.kbs.msu.edujºl¿
-
-	emich.eduûL§
-!
-filemakerserver.albion.eduz|ì
-
-
-calvin.eduéjô
-
-alma.edu	˙e¿
-
-	delta.eduÅÅÖ°
-
-origin1.internet2.edu$˝£
-
-	emich.edu	ûL§
-
-cherwelltest.calvin.eduÀjô
-
-apps.baker.edu⁄Pû
-
-pa-vpn-1.calvin.edu©jô
-
-
-calvin.edu©jô
-
-uturn.calvin.eduéjô
-
-	delta.eduõÅÖ°
-
-origin.internet2.edu$˝£
-
-	emich.edu≤ûL§
-
-sl-um-ps01-bw.slateci.ioÁ)¿
-
-getconnected.calvin.edu
-Œjô
-
-pa-vpn-1.calvin.edu©jô
-
-	emich.edu[ûL§
-
-alma.edu.˙e¿
-
-cherwelldev.calvin.eduÀjô
-
-www4.gvsu.eduê=î
-
-alma.edu[˙e¿
-
-deltavpn.delta.eduÅÅÖ°
-
-jobe.calvin.eduU˝jô
-
-alma.edu/˙e¿
-
-	mylmc.orgDhm¿
-
-	delta.eduÅÖ°
-
-	delta.edu%ÅÖ°
-
-	emich.eduWL§
-
-datanuggets.org’qÁ¿
-
-sl-um-ps01.slateci.ioÁ)¿
-
-lakemichigancollege.edu˛hm¿
-
-panorama.calvin.edu©jô
-
-alma.edu.˙e¿
-
-learnpdc.orgT˝jô
-
-panorama.calvin.edu©jô
-
-alma.edu.˙e¿
-
-	emich.edu1ûL§
-
-	emich.eduµL§
-
-	emich.eduªûL§
-
-ezproxy.emich.edu7L§
-
-
-calvin.edu©jô
-
-alma.edu.˙e¿
-
-alma.edu-˙e¿
-
-images.apple.com¢∫z¿
-
-	delta.eduúÅÖ°
-
-images.apple.com§∫z¿
-
-xn--ngstr-lra8j.comXπz¿
-
-	delta.edu!ÅÖ°
-
-	emich.eduQûL§
-
-learningspace.delta.eduLÖ°
-
-alma.edu.˙e¿
-
-lakemichigancollege.eduhm¿
-
-	emich.edu´ûL§
-
-aquinas.eduå\¿
-
-	emich.edu6L§
-
-vmbg.alma.edu[˙e¿
-
-pa-vpn-2.calvin.edu©jô
-
-	mylmc.orgIhm¿
-
-psumvm02.aglt2.org*Á)¿
-
-	delta.edu1ÅÖ°
-%
-meshconfig.opensciencegrid.orgiÏ)¿
-
-psumvm01.aglt2.org-Á)¿
-
-jenkins.csel.io;∆
-
-	emich.eduóL§
-
-	delta.edu†ÅÖ°
-
-	emich.edu	ûL§
-
-lter.kbs.msu.eduÓºl¿
-
-alma.edu-˙e¿
-
-omd.aglt2.org˝Á)¿
-
-pa-5220-1.calvin.edu©jô
-
-lakemichigancollege.edu hm¿
-
-	delta.eduåÅÖ°
-
-	emich.edu=L§
-
-vmbg.alma.edu[˙e¿
-
-sl-um-ps01-bw.slateci.ioÛÁ)¿
-
-plv.cs.colorado.edu
-;∆
-
-
-calvin.edu»jô
-
-lakemichigancollege.eduGhm¿
-#
-psconfig.opensciencegrid.orgiÏ)¿
-
-mcc.eduO£ô¿
-
-kettering.edu2âä¿
-
-aquinas.edu¢\¿
-&
-registration.refraction.network|æz¿
-
-phd.cs.colorado.edu
-;∆
-
-cumulus.rc.colorado.eduå;∆
-
-kettering.eduââä¿
-
-www.cs.colorado.edu
-;∆
-
-epic.cs.colorado.edu
-;∆
-
-vmbg.alma.edu[˙e¿
-
-alma.edu.˙e¿
-!
-foundation.cs.colorado.edu;∆
-
-oshtemo.kbs.msu.eduÁqÁ¿
-
-alma.eduv˙e¿
-%
-meshconfig.opensciencegrid.orgiÏ)¿
-
-kettering.eduââä¿
-
-iot.cs.calvin.edu√jô
-
-gprpc32.kbs.msu.eduMºl¿
-
-pl.cs.colorado.edu
-;∆
-
-mfm.colorado.edu
-;∆
-
-alma.edu\˙e¿
-
-www.lter.kbs.msu.eduÓºl¿
-
-alma.edu	˙e¿
-
-psconfig.aglt2.orgiÏ)¿
-
-	emich.edu÷ûL§
-
-inginious.csel.io%;∆
-
-vmbg.alma.edu[˙e¿
-
-home2.cs.colorado.edu(;∆
-
-hcc.cs.colorado.edu
-;∆
-
-dev.grafana.csel.io;∆
-
-kettering.eduõâä¿
-
-redirector.colorado.edu
-;∆
-
-images.apple.com∞∫z¿
-
-vpn-tcom.colorado.edu%7;∆
-
-houghton.kbs.msu.edu qÁ¿
-
-home3.cs.colorado.edu(;∆
-
-cloud.cs.colorado.eduÜ;∆
-
-csel-web.cs.colorado.edu;∆
-
-pnd.colorado.edu;∆
-
-autonomy.colorado.edu
-;∆
- 
-runestone.cs.colorado.edu$;∆
-
-lakemichigancollege.eduhm¿
-
-kettering.eduõâä¿
-
-lakemichigancollege.edu1hm¿
- 
-pondhawk.knet.kbs.msu.edu†qÁ¿
-
-lter.msu.eduÓºl¿
-
-alma.edu.˙e¿
-
-inginious.colorado.edu%;∆
-
-workspace.mcc.eduD£ô¿
-
-vpn.colorado.edu&7;∆
- 
-wkuf-router.kettering.edué¸ı¿
-
-wkuf.fm
-¿†¿
-
-kettering.edu2âä¿
-%
-cs2400-applied.cs.colorado.edu";∆
-$
-play-lh.googleusercontent.comXπz¿
-"
-applied-sql.cs.colorado.edu1;∆
-
-vpn-tcom.colorado.edu&7;∆
-+
-$cite-worthiness.scienceofscience.org—F;∆
-
-vmbg.alma.edu[˙e¿
-
-correll.cs.colorado.edu
-;∆
-
-vpn-tcom.colorado.eduÀ7;∆
- 
-inginious.cs.colorado.edu%;∆
-
-home.cs.colorado.edu(;∆
-
-cs2400.cs.colorado.edu!;∆
-
-jupyter.cs.colorado.edu
-;∆
-
-cloud.cs.colorado.eduÜ;∆
-
-aaof-gw-fin.merit.edul∆
-
-focs.cs.colorado.edu+;∆
-
-lakemichigancollege.edu7hm¿
-
-moodle.cs.colorado.edu#;∆
-
-images.apple.com£∫z¿
-
-vpn2.colorado.edu%7;∆
-
-spinks.kbs.msu.edu;qÁ¿
-
-applied.cs.colorado.edu4;∆
-
-vpn.colorado.edu%7;∆
-
-cloud.cs.colorado.eduÜ;∆
-*
-#ondemand-devidp.rc.int.colorado.edu3;∆
-
-kettering.eduõâä¿
-
-mcc.eduW£ô¿
-
-coding.colorado.edu
-;∆
-
-focs2021.cs.colorado.edu+;∆
-
-csfinance.colorado.edu;∆
-
-focs.colorado.edu+;∆
-
-vpn2.colorado.eduÀ7;∆
-
-runestone.colorado.edu$;∆
-
-thetford.kbs.msu.edu¯qÁ¿
-
-vpn2.colorado.edu&7;∆
-
-csr.csel.io;∆
-
-vpn-comp.colorado.eduÀ7;∆
-
-cloud.cs.colorado.eduÜ;∆
-
-cloud.cs.colorado.eduÜ;∆
-%
-ondemand-rmacc.rc.colorado.edu3;∆
- 
-www.museweb.bronsonhg.orgål∆
-
-lakemichigancollege.edu*hm¿
-"
-applied-sql.cs.colorado.edu1;∆
-
-coding.cs.colorado.edu
-;∆
-
-lakemichigancollege.eduFhm¿
-
-vpn-tcom.colorado.edu 7;∆
-
-vpn-comp.colorado.edu 7;∆
-
-vpndev-tcom.colorado.edu∫R;∆
-
-cloud.cs.colorado.eduÜ;∆
-
-vpn-comp.colorado.edu&7;∆
-
-vpndev-comp.colorado.edu∫R;∆
-
-
-vizwiz.org2;∆
-
-kettering.eduââä¿
-
-vpndev2.colorado.edu∫R;∆
-
-www.lter.msu.edu qÁ¿
-
-museweb.bronsonhg.orgål∆
-
-gptest.bronsonhg.orgål∆
-
-cloud.cs.colorado.eduÜ;∆
-!
-rcamp1.rc.int.colorado.edu3;∆
-
-cumulus.rc.colorado.eduå;∆
-
-bluepie.mcc.eduL£ô¿
-
-	mylmc.org3hm¿
-
-vpn2.colorado.edu 7;∆
-
-vpn.colorado.eduÀ7;∆
-
-cumulus.rc.colorado.eduå;∆
-
-rcamp1.rc.colorado.edu3;∆
-
-kettering.eduââä¿
-
-cumulus.rc.colorado.eduå;∆
-
-pondhawk.kbs.msu.edu†qÁ¿
-
-cumulus.rc.colorado.eduå;∆
-
-vizwiz.cs.colorado.edu2;∆
-"
-applied-dev.cs.colorado.edu6;∆
-
-build.cs.colorado.edu;∆
-
-bengine.csel.io#;∆
-
-vpndev.colorado.edu∫R;∆
-
-belt.rc.colorado.edu[S;∆
-
-atlasweb.bronsonhg.orgGål∆
-
-datanuggets.com’qÁ¿
-
-rcamp3.rc.colorado.edu3;∆
-
-kettering.eduΩâä¿
-
-vpn.colorado.edu 7;∆
-"
-applied-sql.cs.colorado.edu1;∆
-
-l3d.colorado.edu“F;∆
-
-bivpriv.colorado.eduêF;∆
-
-cumulus.rc.colorado.eduå;∆
-
-bluepie.mccad.mcc.eduL£ô¿
-
-kettering.eduõâä¿
-
-aaof-gw-fin.merit.edul∆
-
-bronsonhg.orgPål∆
-
-jhub.grafana.csel.ioi;∆
- 
-mychart.bronsonhealth.comfål∆
-
-cs.colorado.edu
-;∆
-
-aaof-gw-msc.merit.edul∆
-
-cumulus.rc.colorado.eduå;∆
-
-cloud.cs.colorado.eduÜ;∆
-
-ondemand.rc.colorado.edu3;∆
-
-mail.bronsonhg.orgiål∆
-
-aaof-gw-netops.merit.edul∆
-
-cloud.cs.colorado.eduÜ;∆
-
-portals.rc.colorado.edu3;∆
-
-aaof-gw-staff.merit.edul∆
-
-aaof-gw-swdev.merit.edul∆
-
-bronsonhg.org@ål∆
-
-aaof-gw-msc.merit.edul∆
- 
-rcamp.rc.int.colorado.edu3;∆
-
-cumulus.rc.colorado.eduå;∆
-
-rcamp.rc.colorado.edu3;∆
-
-xdmod.rc.colorado.edu3;∆
-!
-autodiscover.bronsonhg.orgiål∆
-
-volunteers.bronsonhg.orgjål∆
-
-aaof-gw-netops.merit.edul∆
-
-bronsonhg.orgçl∆
-
-bronsonhg.org±ål∆
-
-smtp.bronsonhg.orgiål∆
-'
- rstudio-bootcamp.rc.colorado.eduS;∆
-
-bronsonhg.org∞ål∆
-
-mychart.wmed.eduwål∆
-
-aaof-gw-it.merit.edul∆
-
-wmed.edu˚îl∆
-
-wmed.edu2îl∆
-
-bronsonhg.orgOål∆
-"
-bmhepichwsx03.bronsonhg.org¢çl∆
-#
-www.volunteers.bronsonhg.orgjål∆
-
-vpn-comp.colorado.edu%7;∆
-
-www.testmvd.borgess.com-èl∆
-"
-bmhepichwsx06.bronsonhg.org¢çl∆
-
-hygieia.bronsonhg.orgsål∆
-
-
-ncmich.edu¿l∆
-
-aaof-gw-staff.merit.edul∆
-%
-mychartsched.bronsonhealth.comfål∆
- 
-pdctemptrak.bronsonhg.orgål∆
-"
-bmhepichwsx10.bronsonhg.org¢çl∆
-
-bronsonhg.orgVål∆
-"
-bmhepichwsx04.bronsonhg.org¢çl∆
-
-aaof-gw-it.merit.edul∆
-
-dbd.sh‡Ml∆
-
-bhgvpn.bronsonhg.orgål∆
-
-cloud.cs.colorado.eduÜ;∆
-
-cumulus.rc.colorado.eduå;∆
-
-aaof-gw-it.merit.edul∆
-
-aaof-gw-fin.merit.edul∆
-
-aaof-gw-netops.merit.edul∆
-"
-bmhepichwsx02.bronsonhg.org¢çl∆
-!
-epiccarelink.bronsonhg.orgål∆
-
-mercury.bronsonhg.orgtål∆
-
-cloud.cs.colorado.eduÜ;∆
-
-vmbg-lan.nmc.eduø«l∆
-
-ezaccess.borgess.com≤èl∆
-
-
-mymcls.comHbl∆
-
-bronsonhg.orgHçl∆
-
-med.wmich.eduîl∆
-
-cumulus.rc.colorado.eduå;∆
-
-vpn.merit.edul∆
-
-mercury.bronsonhg.orgtål∆
-
-vpn.merit.edul∆
-
-aaof-gw-sec.merit.edul∆
-"
-bmhepichwsx08.bronsonhg.org¢çl∆
-
-catalog.tadl.orgG⁄l∆
-
-guac-1.tadl.orgF⁄l∆
-!
-rcamp3.rc.int.colorado.edu3;∆
-
-bronsonhg.orgål∆
-
-aaof-gw-sec.merit.edul∆
-
-aaof-gw-swdev.merit.edul∆
-
-www.mychart.wmcc.org¶çl∆
-
-aaof-gw-msc.merit.edul∆
-
-imap.bronsonhg.orgiål∆
-
-aaof-gw-swdev.merit.edul∆
-
-micollab.nmc.eduø«l∆
-
-aaof-gw-sec.merit.edul∆
-
-aaof-gw-staff.merit.edul∆
-
-bronsonhg.org∞çl∆
-
-chaos.bronsonhg.orgzål∆
- 
-www.mychart.avsurgery.com∫çl∆
-
-www.mymcls.comHbl∆
-
-bronsonhg.orgHçl∆
-
-vpn.merit.edul∆
-
-aaof-gw-sec.merit.edul∆
-
-bronsonhg.org†çl∆
-
-dbd.sh‡Ml∆
-
-aaof-gw-staff.merit.edul∆
-
-bronsonhg.org{ål∆
- 
-slicerdicer.bronsonhg.org¸çl∆
-
-aaof-gw-it.merit.edul∆
-
-bronsonhg.orghçl∆
-
-Security.Adrian.edu
-Pl∆
-
-aaof-gw-fin.merit.edul∆
-"
-bmhepichwsx05.bronsonhg.org¢çl∆
-
-aaof-gw-msc.merit.edul∆
-
-bronsonhg.org≤çl∆
-
-Security.Adrian.edu
-Pl∆
-
-med.wmich.edu˙îl∆
-!
-visualizetst.bronsonhg.orgπçl∆
-"
-bmhepichwsx07.bronsonhg.org¢çl∆
-
-Erebus.bronsonhg.org¢çl∆
-
-www.cteps.dsisd.netÙl∆
-
-mason-oceana911.orgGõl∆
-
-bronsonhg.orgål∆
-
-vmbg-lan.nmc.eduø«l∆
-!
-bmhcogitosd2.bronsonhg.org¸çl∆
-
-fhckzoo.comâål∆
-
-vmbg-lan.nmc.eduø«l∆
-
-mychart.avsurgery.com∫çl∆
-
-landesk.bronsonhg.orgål∆
-!
-bmhcogitosd1.bronsonhg.org¸çl∆
-
-www.mychart.kzoo.edu6çl∆
-
-www.iconnect.borgess.comQèl∆
-&
-ondemand-devidp.rc.colorado.edu3;∆
-
-med.wmich.eduîl∆
-
-cteps.dsisd.netÙl∆
-
-ntwps.dsisd.net7Ùl∆
-
-iconnect.borgess.comQèl∆
-
-www.brhps.dsisd.net4Ùl∆
-
-zuercherportal.comLõl∆
-
-bronsonhg.org±çl∆
-
-mercury.bronsonhg.orgtål∆
-
-mail.menomineeco.comÒl∆
-
-bronsonhg.orgëål∆
-
-mychart.kzoo.edu6çl∆
-
-ica.apps.tadl.orga⁄l∆
-
-mail.deltacountymi.orgd˝l∆
-"
-bmhepichwsx01.bronsonhg.org¢çl∆
-
-fm.adrian.eduRl∆
-
-bronsonhg.orgål∆
-
-rochestermi.org£Ãl∆
-
-aaof-gw-swdev.merit.edul∆
-%
-www.visualizetst.bronsonhg.orgπçl∆
-$
-www.pdctemptrak.bronsonhg.orgål∆
-
-mpsps.dsisd.net3Ùl∆
-
-visualize.bronsonhg.org∏çl∆
-
-catalog.tadl.orgb⁄l∆
-
-bronsonhg.orgíål∆
-
-bronsonhg.orgeçl∆
-
-mychart.med.wmich.eduwål∆
-
-www.mpsps.dsisd.net3Ùl∆
-$
-www.slicerdicer.bronsonhg.org¸çl∆
-
-micollab.nmc.eduø«l∆
- 
-www.museweb.bronsonhg.orgål∆
-
-menomineeco.comÒl∆
-
-brhps.dsisd.net4Ùl∆
-
-jail.deltacountymi.orgl˝l∆
-
-micollab.menomineeco.com
-Òl∆
-
-www.cteps.dsisd.netÙl∆
-
-bbdps.dsisd.net8Ùl∆
-
-office.deltacountymi.orgi˝l∆
-#
-www.micollab.menomineeco.com
-Òl∆
-
-catalog.tadl.orgo⁄l∆
-
-wmed.eduîl∆
- 
-mychart.bronsonhealth.comªçl∆
-
-vpn.merit.edul∆
-
-portal.aircare.orgÔîl∆
-
-ebb.opacs.tadl.orgi⁄l∆
-
-testmvd.borgess.com-èl∆
-
-ica.tadl.netr⁄l∆
-%
-mychartsched.bronsonhealth.comªçl∆
-
-bronsonhg.org≤ål∆
-#
-www.micollab.menomineeco.com
-Òl∆
-
-help.deltacountymi.govq˝l∆
-
-ntwps.dsisd.net7Ùl∆
-
-listserver.udmercy.edu	m∆
-
-	remc1.netÇ˝l∆
-
-mason-oceana911.orgHõl∆
-
-micollab.menomineeco.com
-Òl∆
-
-www.mail.menomineeco.comÒl∆
-
-www.zuercherportal.comLõl∆
-
-micollab.nmc.eduø«l∆
-
-newhistory.tadl.orgh⁄l∆
-
-via.tadl.orgv⁄l∆
-
-mychart.wmcc.org¶çl∆
-
-sandbox.dsisd.net<Ùl∆
-
-	remc1.netÉÙl∆
-
-wmed.edu/îl∆
-
-ps.dsisd.net:Ùl∆
-!
-www.mail.deltacountymi.orgd˝l∆
-
-micollab.nmc.eduø«l∆
-
-udmercy.edudm∆
-"
-www.visualize.bronsonhg.org∏çl∆
-
-med.wmich.edu9îl∆
-
-udmercy.edu◊m∆
-
-micollab.menomineeco.com
-Òl∆
-
-brhps.dsisd.net4Ùl∆
-"
-bmhepichwsx09.bronsonhg.org¢çl∆
-#
-www.micollab.menomineeco.com
-Òl∆
-
-www.mpsps.dsisd.net3Ùl∆
-
-www.brhps.dsisd.net4Ùl∆
-
-micollab.menomineeco.com
-Òl∆
-
-mail.menomineeco.comÒl∆
-
-micollab.menomineeco.com
-Òl∆
-
-udmercy.edu¨m∆
- 
-www.powerschool.dsisd.net=Ùl∆
-
-udmercy.edu!m∆
-
-mail.deltacountymi.govd˝l∆
-
-med.wmich.eduîl∆
-
-micollab.menomineeco.com
-Òl∆
-
-www.mobilmad.madonna.edunHm∆
-
-mpsps.dsisd.net3Ùl∆
-
-vpn.deltacountymi.govb˝l∆
-
-www.sfweb.copesd.orgK‹l∆
-
-mail.deltacountymi.orgd˝l∆
-
-www.ttsps.dsisd.net9Ùl∆
-
-udmercy.edu˙m∆
-
-udmercy.edu	m∆
-
-
-ncmich.edu2¿l∆
-
-vmbg-lan.nmc.eduø«l∆
-
-listserver.udmercy.edu	m∆
-!
-airwatch.deltacountymi.orgf˝l∆
-&
-www.server1.netcomcomputers.com7km∆
-
-udmercy.edu‘m∆
-
-choosests.comkm∆
-
-ica.tadl.nets⁄l∆
-
-cloud.deltacountymi.govi˝l∆
-
-ps.dsisd.net:Ùl∆
-
-cmhmail.scccmha.orgIYm∆
-
-micollab.menomineeco.com
-Òl∆
-!
-www.mail.deltacountymi.orgd˝l∆
-
-admin.legislature.mi.gov¥≠m∆
- 
-www.powerschool.dsisd.net=Ùl∆
-
-access.scccmh.orgIYm∆
-
-	arbor.edu∏¬m∆
-
-legislature.mi.govØ≠m∆
- 
-records.deltacountymi.govg˝l∆
-
-micollab.menomineeco.com
-Òl∆
-
-mail.deltacountymi.orgd˝l∆
-
-ttsps.dsisd.net9Ùl∆
-
-mail.deltacountymi.govd˝l∆
-
-www.bbdps.dsisd.net8Ùl∆
-
-powerschool.dsisd.net=Ùl∆
-
-access.scccmha.orgIYm∆
-
-cloud.deltacountymi.orgi˝l∆
-
-mbg.mwse.org(√m∆
-
-autodiscover.scccmha.orgIYm∆
-$
-autodiscover.sienaheights.edu⁄m∆
-
-mail.deltacountymi.govd˝l∆
-
-admin.legislature.mi.govÆ≠m∆
-
-www.ps.dsisd.net:Ùl∆
-
-www.ntwps.dsisd.net7Ùl∆
-
-fm.corbindesign.comIkm∆
-!
-www.mail.deltacountymi.orgd˝l∆
-
-www.sandbox.dsisd.net<Ùl∆
-
-udmercy.eduAm∆
- 
-www.vpn.deltacountymi.govb˝l∆
-
-www.fm.corbindesign.comIkm∆
-
-ironwood.gogebic.eduÄn∆
-
-udmercy.eduÂm∆
-
-sfweb.copesd.orgK‹l∆
-#
-www.micollab.menomineeco.com
-Òl∆
-
-scccmha.orgIYm∆
-
-mail.deltacountymi.govd˝l∆
-
-jail.deltacountymi.govl˝l∆
-
-mail.sienaheights.edu(⁄m∆
-
-hosted.tadl.orgx⁄l∆
-
-mail.deltacountymi.orgd˝l∆
-
-cteps.dsisd.netÙl∆
-
-ironwood.gogebic.eduíÄn∆
-
-micollab.menomineeco.com
-Òl∆
-
-admin.legislature.mi.gov´≠m∆
-
-www.ttsps.dsisd.net9Ùl∆
-
-mca-2.mwse.org(√m∆
-
-	arbor.edu¬m∆
-
-bbdps.dsisd.net8Ùl∆
-
-www.menomineeco.comÒl∆
-
-ironwood.gogebic.eduÄn∆
-!
-www.mail.deltacountymi.orgd˝l∆
-
-www.ntwps.dsisd.net7Ùl∆
-
-www.rdp.mwse.org-√m∆
-
-med.wayne.eduáGm∆
-
-udmercy.edu™m∆
-
-mail.deltacountymi.orgd˝l∆
-
-ironwood.gogebic.eduÖÄn∆
-
-ironwood.gogebic.edu
-Än∆
-
-fm.corbindesign.comIkm∆
-
-admin.legislature.mi.gov™≠m∆
-
-www.atafordpas.orgym∆
-!
-www.mail.deltacountymi.orgd˝l∆
-
-hillsdalebpu.com√m∆
-
-ironwood.gogebic.eduÉÄn∆
-
-mca.mwse.org(√m∆
-
-miottawa.org	Wn∆
-
-www.scccmh.orgIYm∆
-"
-server1.netcomcomputers.com7km∆
-
-www.ps.dsisd.net:Ùl∆
-
-house.mi.govπ≠m∆
-
-legislature.mi.gov´≠m∆
-
-www.help.jccmi.edu†»m∆
-
-	remc1.netÉÙl∆
-
-ironwood.gogebic.eduFÄn∆
-
-	gisbr.comdên∆
-
-hillsdalebpu.com√m∆
-'
- www.5ba0d9f8ebb3f.streamlock.net≠m∆
-
-audgen.michigan.gov=≠m∆
-
-www.fm.corbindesign.comIkm∆
-$
-autodiscover.sienaheights.edu(⁄m∆
- 
-rod.dickinsoncountymi.gov)„m∆
-
-ttsps.dsisd.net9Ùl∆
-
-sandbox.dsisd.net<Ùl∆
-
-med.wayne.edu≈çm∆
-
-legislature.mi.gov¥≠m∆
-
-mbg.mwse.org(√m∆
-
-ironwood.gogebic.eduÅn∆
-#
-www.acctsql.brt.badriver.comdên∆
-
-grdc-view02.merit.edu-tn∆
-
-cmhexchange.scccmha.orgIYm∆
-
-legislature.mi.govÆ≠m∆
-!
-airwatch.deltacountymi.orgf˝l∆
-
-superiorconnections.comdên∆
-
-view2.merit.edu-tn∆
-
-mobilmad.madonna.edunHm∆
-
-acctsql.brt.badriver.comyên∆
-
-badriver-nsn.govyên∆
-
-myuser1.nmu.edu=¿n∆
-&
-www.vpn-specialprojects.ltu.eduƒën∆
- 
-corbinet.corbindesign.comKkm∆
-
-myuser2.nmu.edu=¿n∆
-
-support.glifwc.org3ên∆
-#
-5ba0d9f8ebb3f.streamlock.net≠m∆
-
-ironwood.gogebic.eduÅn∆
-
-badriver.comyên∆
- 
-records.deltacountymi.orgg˝l∆
-
-rdp.mwse.org-√m∆
-
-brm.badriver.comdên∆
-
-mbg.mwse.org(√m∆
-
-myuser.nmu.edu=¿n∆
-
-acctsql.brt.badriver.comdên∆
-
-ironwood.gogebic.eduìÄn∆
-
-cmhsecure.scccmh.orgIYm∆
-
-myusr2.nmu.edu=¿n∆
-
-lib.nmu.edu¬n∆
-
-help.jccmi.edu†»m∆
-
-badriverhwc.comdên∆
-
-sienaheights.edu⁄m∆
-
-mbg.mwse.org(√m∆
-
-pinkytest.vai.org
-ßn∆
-
-mlist.nmu.edu«n∆
-
-autodiscover.scccmh.orgIYm∆
-
-ironwood.gogebic.eduîÄn∆
-&
-www.server1.netcomcomputers.com7km∆
-
-brclock.comyên∆
-
-ironwood.gogebic.edu¢Än∆
-
-gis.badriver-nsn.gov{ên∆
-(
-!merit-pdreceiver-prod02.merit.edutn∆
-
-mca-2.mwse.org(√m∆
-
-house.mi.govπ≠m∆
-
-admin.legislature.mi.govØ≠m∆
-
-www.gis.badriver-nsn.gov{ên∆
-
-beaker.nmu.edu«n∆
-
-nmuebs.nmu.edu«n∆
-
-myusr1.nmu.edu=¿n∆
-
-vpn-abroad.ltu.eduÀën∆
-
-ww-library.nmu.edu¬n∆
-
-ezpolson.nmu.edu¬n∆
-
-ittech.nmu.edu«n∆
-
-grdc-view01.merit.edu-tn∆
-
-hillsdalebpu.com√m∆
-
-	myjdl.com˙€m∆
-
-legislature.mi.gov™≠m∆
-$
-www.corbinet.corbindesign.comKkm∆
-
-mbg.mwse.org(√m∆
-
-brclock.comdên∆
-
-
-scccmh.orgIYm∆
-
-enterprise.nmu.edu«n∆
-
-btpl.orgêrm∆
-
-devorientation.nmu.eduH«n∆
-
-	gisbr.comyên∆
-
-brtremote.comdên∆
-
-www.brclock.comdên∆
-"
-server1.netcomcomputers.com7km∆
-
-photo.nmu-media.com»n∆
-
-hillsdalebpu.com
-√m∆
-
-grdc-vsec02.merit.edu-tn∆
-
-brm.badriver.comyên∆
-
-ironwood.gogebic.edu	Än∆
-
-sienaheights.edu(⁄m∆
-
-badriver-nsn.govdên∆
-
-dev.nmu-media.com»n∆
-
-superiorconnections.comyên∆
-
-goccsc.glenoaks.edu„m∆
-
-marbles.nmu.edu»n∆
-
-www.goccsc.glenoaks.edu„m∆
-
-web1.vai.orgTßn∆
-
-alexandria.nmu.edud»n∆
-
-devapply.nmu.eduH«n∆
-
-imginfo.nmu.edu«n∆
-
-nmuebs.nmu.edu«n∆
-
-vpn-test.ltu.eduÃën∆
-
-kettering.edu«n∆
-
-nmu.eduA»n∆
-
-fwvpna.vai.org
-ßn∆
-
-www.vpn-abroad.ltu.eduÀën∆
-
-up200nmu.com»n∆
-
-umcdev1.nmu.edu´Àn∆
-*
-#lyncdiscoverinternal.baycollege.edu!’n∆
-
-internal.nmu.eduG«n∆
-
-webconf1.baycollege.edu‘n∆
-
-listserv.nmu.edu«n∆
-
-mytest.nmu.eduÿ»n∆
-
-news.nmu.eduA»n∆
-
-ezproxy.myjdl.com˝€m∆
-
-rocky.nmu.edu1¿n∆
-
-mbg.mwse.org(√m∆
-
-news.nmu-media.orgA»n∆
-
-www-library3.nmu.edu¬n∆
-
-beaker.nmu.edu«n∆
-
-nmu-media.orgA»n∆
-
-badriver.comdên∆
-
-testvpn.vai.org
-ßn∆
-
-imginfo.nmu.edu«n∆
-
-enterprise.nmu.edu«n∆
-
-mail.sienaheights.edu⁄m∆
-
-oab.baycollege.edu(’n∆
-
-mlshare.nmu.edu«n∆
-
-mapssecconn.mapsnet.org
-«n∆
-
-lstsrv.nmu.edu«n∆
-
-foundation.nmu-media.orgA»n∆
-(
-!autodiscover.sheridanhospital.como∆
-
-www.brclock.comyên∆
-
-
-macomb.eduG8o∆
-
-ittech.nmu.edu«n∆
-"
-vpn-specialprojects.ltu.eduƒën∆
-
-dialin.baycollege.edu!’n∆
-
-umcdev1-dev.nmu.edu´Àn∆
-
-foundation.nmu.eduA»n∆
-#
-www.acctsql.brt.badriver.comyên∆
-
-pinky.vai.org
-ßn∆
-
-mca.mwse.org(√m∆
-
-ike2jj.nmu.eduŒn∆
-
-
-macomb.eduP8o∆
-
-maap.org»n∆
-
-kci-net.karmanos.orgä¯n∆
-
-pigpen.nmu.edu«n∆
-
-
-macomb.eduw8o∆
-
-mailshare.nmu.edu«n∆
-
-wildcast.nmu.eduE«n∆
-
-maap.nmu-media.com»n∆
-#
-schmail.sheridanhospital.como∆
-
-franklin.nmu.eduA»n∆
-
-umcdev1-news.nmu.edu´Àn∆
-
-leo.nmu.eduÿ»n∆
-
-eanasset.nmu.edu$«n∆
-
-ews.baycollege.edu'’n∆
-
-libcal.nmu.edu¬n∆
-
-oab.baycollege.edu)’n∆
-
-brtremote.comyên∆
-
-webconf1.baycollege.edu‘n∆
-
-library.nmu.edu¬n∆
-
-karmanos.orgå¯n∆
-
-atafordpas.orgym∆
-
-ike2km.nmu.eduŒn∆
-$
-www.rod.dickinsoncountymi.gov)„m∆
-
-eas.baycollege.edu'’n∆
-
-northgate.lssu.edu‹n∆
-
-
-macomb.eduö8o∆
-
-idp.nmu.edu1»n∆
-
-
-macomb.edu§8o∆
-
-grdc-vsec01.merit.edu-tn∆
-
-ews.baycollege.edu(’n∆
-
-ctlregister.nmu.edu¬n∆
-
-
-macomb.eduú8o∆
-
-
-macomb.edu≠8o∆
-
-cmssso.nmu.eduê»n∆
-
-outlook.baycollege.edu)’n∆
-
-nmu.college´Àn∆
-
-photo.up200nmu.com»n∆
-
-sheridanhospital.como∆
-
-webconf1.baycollege.edu‘n∆
-
-gitlib.nmu.edu¬n∆
-
-pigpen.nmu.edu«n∆
-"
-lyncdiscover.baycollege.edu!’n∆
-
-nmudrive.nmu.edud»n∆
-
-www-library2.nmu.edu¬n∆
-
-webconf1.baycollege.eduÒ‘n∆
-
-mas.baycollege.edu‘n∆
-!
-umcdev1-foundation.nmu.edu´Àn∆
-&
-securemail.sheridanhospital.com1o∆
-
-skype.baycollege.edu!’n∆
-
-ike2.nmu.eduŒn∆
-&
-securemail.sheridanhospital.com.o∆
-
-baycollege.edu'’n∆
-
-spaces.nmu.edu¬n∆
-
-webconf1.baycollege.edu‘n∆
-
-umc-media.nmu.eduàÀn∆
-
-lyncadmin.baycollege.edu!’n∆
-#
-schspam.sheridanhospital.com1o∆
-
-mram.nmu.edu:«n∆
-
-mail.baycollege.edu)’n∆
-
-nmu-media.com»n∆
-
-www.gateway.holyfam.org>o∆
-
-mail.baycollege.edu'’n∆
-
-clconnect-test.lssu.eduáÿn∆
-&
-securemail.sheridanhospital.como∆
-
-outlook.baycollege.edu(’n∆
-
-www.vpn-test.ltu.eduÃën∆
-
-umcdev4.nmu.edu≈Àn∆
-
-karmanos.org¯n∆
-
-prtg.lssu.eduåÿn∆
-
-kci-net.karmanos.org¯n∆
-
-educat.nmu.eduŒn∆
-
-roundcube.nmu.edu1¿n∆
-&
-securemail.sheridanhospital.como∆
-
-ews.baycollege.edu)’n∆
-
-eas.baycollege.edu+’n∆
-
-meet.baycollege.edu!’n∆
-%
-vpn.dickinsoncountysheriff.net¢◊n∆
-
-webmail.nmu.edu1¿n∆
-
-
-macomb.educ9o∆
-
-thdwebtest.nmu.edu—»n∆
-#
-schspam.sheridanhospital.como∆
-
-apps.nmu.eduG«n∆
-
-
-macomb.eduò8o∆
-
-aquinas.eduÇın∆
-
-sheridanhospital.com2o∆
-
-
-macomb.eduç9o∆
-&
-securemail.sheridanhospital.como∆
-
-sheridanhospital.como∆
-
-mas.baycollege.edu‘n∆
-
-northgate.lssu.edu⁄n∆
-
-baycollege.edu(’n∆
-"
-autodiscover.baycollege.edu'’n∆
-
-rhpl.orgo¢o∆
-#
-schmail.sheridanhospital.com.o∆
-
-sheridanhospital.com4o∆
-
-oab.baycollege.edu+’n∆
-
-th-mbg.waterfordmi.govI¢o∆
-#
-schspam.sheridanhospital.como∆
-
-sip.baycollege.edu!’n∆
-
-dev.nmu-media.orgA»n∆
-%
-sches.sch.sheridanhospital.com1o∆
-
-th-mbg.waterfordmi.govI¢o∆
-"
-autodiscover.baycollege.edu)’n∆
-
-mas.baycollege.edu‘n∆
-(
-!autodiscover.sheridanhospital.com.o∆
-
-kci-net.karmanos.orgå¯n∆
-&
-wideload.network.baycollege.edu!’n∆
-"
-autodiscover.baycollege.edu+’n∆
-
-karmanos.orgä¯n∆
-(
-!autodiscover.sheridanhospital.como∆
-
-mas.baycollege.edu‘n∆
-
-southfieldlibrary.org¢o∆
-%
-goldbug.network.baycollege.edu!’n∆
-
-mybay.baycollege.edu|‘n∆
-
-gateway.holyfam.org>o∆
-
-eas.baycollege.edu(’n∆
-%
-rollbar.network.baycollege.edu!’n∆
-#
-schspam.sheridanhospital.com.o∆
-
-outlook.baycollege.edu'’n∆
-
-housing.nmu.eduÀ»n∆
-(
-!autodiscover.sheridanhospital.com1o∆
-
-oos.baycollege.edu;’n∆
-
-	remc1.net¡◊n∆
-
-webconf1.baycollege.edu‘n∆
-%
-sches.sch.sheridanhospital.com.o∆
-
-sheridanhospital.com1o∆
-
-th-mbg.waterfordmi.govI¢o∆
-
-sheridanhospital.como∆
-
-
-macomb.eduQ8o∆
-%
-sches.sch.sheridanhospital.com2o∆
-!
-autodiscover.is.wccnet.org#∞o∆
-(
-!autodiscover.sheridanhospital.como∆
-
-northgate.lssu.edu›n∆
-
-eas.baycollege.edu)’n∆
-
-aquinas.edum˘n∆
-
-outlook.baycollege.edu+’n∆
-"
-th-micollab.waterfordmi.govI¢o∆
-"
-th-micollab.waterfordmi.govI¢o∆
-
-th-mbg.waterfordmi.govI¢o∆
-
-apps.waterfordmi.gov £o∆
-%
-sches.sch.sheridanhospital.como∆
-#
-schspam.sheridanhospital.como∆
-#
-schspam.sheridanhospital.como∆
-
-prtg2.lssu.eduåÿn∆
-!
-www.ydlpay.ypsilibrary.org®ßo∆
-)
-"www.vpn.dickinsoncountysheriff.net¢◊n∆
- 
-ruiru1-dev.dev.wccnet.org,∞o∆
-
-mail.baycollege.edu+’n∆
-#
-schspam.sheridanhospital.com2o∆
-#
-schmail.sheridanhospital.como∆
-
-northgate.lssu.eduŸn∆
-
-northgate.lssu.eduﬂn∆
-"
-autodiscover.baycollege.edu(’n∆
-
-catalog.cantonpl.orgC§o∆
- 
-inform.mackinacbridge.orgΩo∆
-
-iphubweb.umcu.orgÁºo∆
-
-karmanos.orgî¯n∆
-"
-th-micollab.waterfordmi.govI¢o∆
-#
-schmail.sheridanhospital.com4o∆
-(
-!autodiscover.sheridanhospital.como∆
-(
-!autodiscover.sheridanhospital.com4o∆
-
-rhpl.orgw¢o∆
-
-client.is.wccnet.org$∞o∆
-
-kci-net.karmanos.orgî¯n∆
-
-royaloakrec.com¶o∆
-
-clconnect-prod.lssu.eduàÿn∆
-
-pac.iamtgc.netÏo∆
-)
-"cpass-ilab-c1.ilab.umnet.umich.eduq‚o∆
- 
-catalog.salinelibrary.org
-≠o∆
-%
-sches.sch.sheridanhospital.com4o∆
-
-sheridanhospital.como∆
-#
-schspam.sheridanhospital.como∆
-#
-schmail.sheridanhospital.como∆
-
-
-wccnet.eduº∞o∆
-
-plymouthlibrary.orgí¶o∆
- 
-ruiru1-dev.dev.wccnet.org,∞o∆
-&
-securemail.sheridanhospital.com4o∆
-
-
-wccnet.eduL∞o∆
-
-aquinas.edu@ın∆
-
-ews.baycollege.edu+’n∆
-!
-autodiscover.is.wccnet.org$∞o∆
-
-webtime.wccnet.eduï∞o∆
-%
-sches.sch.sheridanhospital.como∆
-#
-schmail.sheridanhospital.com1o∆
-
-s3w.cantonpl.orgE§o∆
-
-mail.baycollege.edu(’n∆
-
-
-wccnet.eduí∞o∆
-
-th-mbg.waterfordmi.govI¢o∆
-
-gis.waterfordmi.govÃ£o∆
-#
-schmail.sheridanhospital.como∆
-%
-sches.sch.sheridanhospital.como∆
-
-ydlpay.ypsilibrary.org®ßo∆
-
-sheridanhospital.como∆
-
-
-wccnet.edu≤∞o∆
-
-hybrid.is.wccnet.org$∞o∆
-
-sheridanhospital.com.o∆
-
-baycollege.edu+’n∆
-
-oab.baycollege.edu'’n∆
-
-cidlibrary.org§o∆
-
-
-macomb.edu8o∆
-#
-schspam.sheridanhospital.com4o∆
-
-
-wccnet.eduW∞o∆
-
-
-wccnet.edu˝∞o∆
-
-www.apps.waterfordmi.gov £o∆
-
-autodiscover.wccnet.edu$∞o∆
-
-umcdev2.nmu.edu¨Àn∆
-
-
-wccnet.eduh∞o∆
-
-pac.iamtgc.netÏo∆
-
-ruiru.is.wccnet.org$∞o∆
-#
-schmail.sheridanhospital.com2o∆
-$
-www.catalog.salinelibrary.org
-≠o∆
-
-th-mbg.waterfordmi.govI¢o∆
-
-rhpl.orgs¢o∆
-
-client.is.wccnet.org#∞o∆
-
-ruiru.is.wccnet.org#∞o∆
-
-iphubweb.umcu.orgÁºo∆
-
-www.gis.waterfordmi.govÃ£o∆
-
-
-wccnet.edu‰∞o∆
-
-th-mbg.waterfordmi.govI¢o∆
-(
-!autodiscover.sheridanhospital.com2o∆
-&
-securemail.sheridanhospital.como∆
-
-autodiscover.wccnet.edu#∞o∆
-
-kellogg.eduoˇÎ∆
-
-catalog.cantonpl.orgC§o∆
-
-itbs.cantonpl.orgE§o∆
-
-ruiru.is.wccnet.org$∞o∆
- 
-mobile.mackinacbridge.orgΩo∆
-(
-!autodiscover.sheridanhospital.como∆
-
-kellogg.edu#ˇÎ∆
-&
-securemail.sheridanhospital.com2o∆
-
-autodiscover.wccnet.edu$∞o∆
-
-www.iphubweb.umcu.orgÁºo∆
-
-kellogg.edu/ˇÎ∆
-
-kellogg.eduˇÎ∆
-
-mauth.cantonpl.orgE§o∆
- 
-ruiru1-dev.dev.wccnet.org,∞o∆
-
-hybrid.is.wccnet.org#∞o∆
-&
-securemail.sheridanhospital.como∆
-
-
-wccnet.eduv∞o∆
-
-hybrid.is.wccnet.org$∞o∆
-
-www.pac.iamtgc.netÏo∆
-
-aadl.orgS&Ã
-
-aquinas.edue˘n∆
-
-www.iphubweb.umcu.orgÁºo∆
-
-
-wccnet.edu+∞o∆
-
-kellogg.edurˇÎ∆
-%
-sches.sch.sheridanhospital.como∆
-
-bssopprd.nmu.edu&Ã
-
-ems.wccnet.edu•∞o∆
-
-vlc.lib.mi.usÃo∆
-
-apache.mtri.org&Ã
-
-bssotest.nmu.edu%&Ã
-
-ne.netscout.comF&Ã
-
-
-wccnet.edu_∞o∆
-%
-sches.sch.sheridanhospital.como∆
-
-managedbyubx.comøo∆
-
-kellogg.eduÇˇÎ∆
-!
-autodiscover.is.wccnet.org$∞o∆
-
-kellogg.eduDˇÎ∆
-
-opg.mtri.org&Ã
-
-kellogg.edu|ˇÎ∆
-
-gravy.wccnet.edu∏∞o∆
-
-
-wccnet.edu·∞o∆
-
-kellogg.edu{ˇÎ∆
-#
-schmail.sheridanhospital.como∆
-
-media.aadl.orgb&Ã
-
-evergreen.aadl.org&Ã
-
-art.nmu.edu6&Ã
-
-pez.wccnet.edu¯∞o∆
-
-aadl.org&Ã
-
-client.is.wccnet.org$∞o∆
-
-www.pac.iamtgc.netÏo∆
-
-	diisd.org0&Ã
-
-webserver.mtri.org&Ã
-
-files.aadl.orgb&Ã
-
-evergreen.aadl.org&Ã
-
-ftp.mtri.org&Ã
-
-kellogg.eduˇÎ∆
-
-	diisd.org0&Ã
-
-hete.arbor.netX&Ã
-
-aadl.orgS&Ã
-
-kellogg.eduˇÎ∆
-
-fhirconnect.altarum.orgºjÃ
-
-kellogg.eduUˇÎ∆
-
-www.royaloakrec.com¶o∆
-
-	diisd.org+0&Ã
-
-kellogg.edu\ˇÎ∆
-
-kellogg.edu(ˇÎ∆
-
-mipscast.org%jÃ
-
-wiki.aadl.org&Ã
-
-bssoprod.nmu.edu
-&Ã
-
-bssoprod.nmu.edu
-&Ã
-
-kellogg.edujˇÎ∆
-
-	remc1.net0&Ã
-
-	diisd.orgG0&Ã
-
-mail.boynecity.comd*Hœ
-"
-www.gis.cityofwakefield.orgt*Hœ
-
-mail.lapeercmh.orgFHœ
-
-kellogg.eduIˇÎ∆
-
-mail.rtdl.orgÍ•o∆
-
-
-wccnet.eduC∞o∆
-
-wsu-elk.osris.org	√'Ã
-
-index.casscountymi.org1Hœ
-
-mipscast.com%jÃ
-
-bssopprd.nmu.edu&Ã
-
-www.mipscast.com%jÃ
-
-	diisd.org0&Ã
-
-utmobile.nmu.edu˛&Ã
-
-www.mail.miworks.orgs(&Ã
-
-nmu3cx.nmu.edu¥Ã&Ã
-
-	diisd.org0&Ã
-
-washtenawliteracy.orgd&Ã
-
-bssotest.nmu.edu%&Ã
-!
-www.index.casscountymi.org1Hœ
-
-kellogg.eduˇÎ∆
-
-vpn.arenaccountymi.gov"(&Ã
-
-bssotest.nmu.edu%&Ã
-!
-qualitymonitor.altarum.org%jÃ
-
-bsso.nmu.edu
-&Ã
-
-bsso.nmu.edu
-&Ã
-!
-AutoDiscover.boynecity.comd*Hœ
-
-	remc1.net0&Ã
-
-www.mipscast.org%jÃ
-
-bssoprod.nmu.edu
-&Ã
-
-gis.cityofwakefield.orgt*Hœ
-
-mail.lapeercmh.orgFHœ
-
-mail.miworks.orgs(&Ã
-
-cooper.nmu.edu¥Ã&Ã
-
-mail.lapeercmh.orgFHœ
-
-cooper.nmu.edu¥Ã&Ã
-
-bsso.nmu.edu
-&Ã
-
-vpn.norcocmh.orgIœ
-!
-AutoDiscover.boynecity.comd*Hœ
-
-vpn.norcocmh.orgIœ
-
-lapeercounty.orgFHœ
-
-www.hete.arbor.netX&Ã
-
-	diisd.org#0&Ã
-
-kellogg.eduGˇÎ∆
-!
-www.mi-connect.altarum.org9Hœ
-
-mail.lapeercmh.orgFHœ
-
-lapeercounty.orgFHœ
-
-wsu-grafana.osris.org√'Ã
-
-www.vpn.norcocmh.orgIœ
-
-vpn.arenaccountymi.gov"(&Ã
-
-boynecity.comd*Hœ
-
-vpn.norcocmh.orgIœ
-
-norcocmh.orgIœ
-
-boynecity.comd*Hœ
-
-mi-connect.altarum.org9Hœ
-
-www.vpn.norcocmh.orgIœ
-
-apsssuite.comK1Hœ
-
-mail.lapeercmh.orgFHœ
-
-www.vpn.norcocmh.orgIœ
-
-www.lapeercounty.orgFHœ
-
-
-my.ltu.eduÒ@Iœ
-
-vpn.norcocmh.orgIœ
-
-www.vpn.norcocmh.orgIœ
-
-mail.boynecity.comd*Hœ
-
-lapeercounty.orgFHœ
-
-vpn.norcocmh.orgIœ
-
-www.vpn.norcocmh.orgIœ
-
-www.support.stjcmi.org
-!Jœ
-
-www.vpn.norcocmh.orgIœ
-
-powerschool.mcbain.orgGJœ
-
-vpn.norcocmh.orgIœ
-
-www.vpn.norcocmh.orgIœ
-
-www.mypassword.ltu.eduj@Iœ
-
-remote.cityofhart.org.5Jœ
-
-vpn.norcocmh.orgIœ
-
-www.vpn.norcocmh.orgIœ
-
-mypassword.ltu.eduj@Iœ
-!
-www.powerschool.mcbain.orgGJœ
-
-vpn.norcocmh.orgIœ
-
-vpn.norcocmh.orgIœ
-
-powerschool.mcbain.orgGJœ
-
-support.stjcmi.org
-!Jœ
-
-www.vpn.norcocmh.orgIœ
-!
-www.powerschool.mcbain.orgGJœ
- 
-www.remote.cityofhart.org.5Jœ
-
-
-wccnet.eduÄIœ
-
-powerschool.mcbain.orgGJœ
-
-www.vpn.norcocmh.orgIœ
-1
-*wmcmh-heart-wired-vrhbgbgqwj.dynamic-m.com¬5Jœ
-
-vpn.norcocmh.orgIœ
-
-smtp.alconahc.orgxMJœ
-
-mccezproxy.palnet.info:!Jœ
-
-imap.alconahc.orgxMJœ
-
-remote.ahcis.netdMJœ
-"
-remote.charlevoixcounty.orgX=Jœ
-
-www.my.ltu.eduÒ@Iœ
-
-mail.alconahc.orgxMJœ
-"
-micollab.hillmanschools.commRJœ
-
-bakerezproxy.palnet.info8!Jœ
-
-gaylord.k12.mi.us%ßJœ
-"
-micollab.hillmanschools.commRJœ
-
-mbg.hillmanschools.commRJœ
-
-mbg.hillmanschools.commRJœ
-
-mbg.hillmanschools.commRJœ
-!
-selfservice.ccsdetroit.edu,√Jœ
-
-gladwincounty-mi.govŸOJœ
- 
-autodiscover.alconahc.orgxMJœ
- 
-autodiscover.alconahc.orgxMJœ
-
-mail.cctransit.orgRßJœ
-3
-,ford-vcs-e.web.collegeforcreativestudies.edu(√Jœ
-
-connect.ahcis.netfMJœ
-
-www.ww3.madonna.edu<®Jœ
-!
-foodservice.wbrc.k12.mi.usÌOJœ
-,
-%pwreset.collegeforcreativestudies.edu√Jœ
-
-www.vpn.norcocmh.orgIœ
-5
-.wmcmh-ludington-wired-jrhwgvmmwj.dynamic-m.comB5Jœ
-
-smtp.alconahc.orgxMJœ
-
-msu-omd.osris.org	ŸIœ
-
-imap.alconahc.orgxMJœ
-!
-selfservice.ccsdetroit.edu,√Jœ
--
-&meredith.collegeforcreativestudies.edu˛√Jœ
-
-voice.nemcworks.org§cKœ
-
-msu-grafana.osris.orgŸIœ
-"
-micollab.hillmanschools.commRJœ
-
-voice.nemcworks.org¢cKœ
-
-vpn.norcocmh.orgIœ
- 
-www.portaldev.madonna.edue®Jœ
-
-aov.kabu.netµOJœ
-
-voice.nemcworks.org¢cKœ
-
-mail.oceanamcf.orgrJœ
-!
-autodiscover.oceanamcf.orgrJœ
-!
-autodiscover.cctransit.orgRßJœ
-
-voice.nemcworks.org§cKœ
-
-www.mail.oceanamcf.orgrJœ
-
-mail.alconahc.orgxMJœ
-
-smtp.alconahc.orgxMJœ
-
-ebill.pieg.com√OJœ
-!
-www.powerschool.mcbain.orgGJœ
-
-smtp.alconahc.orgxMJœ
-+
-$campus.collegeforcreativestudies.edu!√Jœ
-3
-,ford-vcs-e.web.collegeforcreativestudies.edu(√Jœ
-
-access.ccsdetroit.edu&√Jœ
-
-imap.alconahc.orgxMJœ
-
-ww3.madonna.edu<®Jœ
-
-mbg.hillmanschools.commRJœ
-
-mail.alconahc.orgxMJœ
-
-mugate.madonna.edu®Jœ
- 
-autodiscover.alconahc.orgxMJœ
-
-voice.nemcworks.org§cKœ
-
-www.mail.cctransit.orgRßJœ
-
-www.sts.montcounty.org¬MJœ
-
-acvpn.mfbhosp.orgÇ∆Jœ
-$
-collegeforcreativestudies.edu(√Jœ
-!
-selfservice.ccsdetroit.edu,√Jœ
-
-oceanamcf.orgrJœ
-
-sfdc-vsec01.merit.eduXtKœ
-.
-'expy-ford.collegeforcreativestudies.edu(√Jœ
-)
-"luna.collegeforcreativestudies.edu»√Jœ
-
-sts.montcounty.org¬MJœ
-0
-)selfservice.collegeforcreativestudies.edu,√Jœ
-
-alpenaschools.comáOJœ
-
-sfdc-view02.merit.eduXtKœ
-
-deepfield.net[•Kœ
-
-sp.training.incommon.org'§Kœ
-
-kettering.edurJœ
-
-www.view.maryfreebed.com¨∆Jœ
-
-mbg.hillmanschools.commRJœ
-
-mail.alconahc.orgxMJœ
-
-vpn.crystalfalls.org)Kœ
-(
-!web.collegeforcreativestudies.edu(√Jœ
-
-mfb-hrz-cb02.mfbhosp.org¨∆Jœ
-
-view.maryfreebed.com¨∆Jœ
-3
-,ford-vcs-e.web.collegeforcreativestudies.edu(√Jœ
-
-vpn.lvdhealthcenter.com\7Kœ
-
-omeka.ccsdetroit.edu7√Jœ
-
-webmail.cctransit.orgRßJœ
-
-portaldev.madonna.edue®Jœ
-
-attendanceondemand.com˚Kœ
-
-voice.nemcworks.org¢cKœ
-
-www.view.maryfreebed.com¨∆Jœ
-
-www.mugate.madonna.edu®Jœ
-.
-'expy-ford.collegeforcreativestudies.edu(√Jœ
-
-www.gis.escanaba.org%(Kœ
-(
-!idp.collegeforcreativestudies.edu&√Jœ
-
-sfdc-view01.merit.eduXtKœ
-
-mfb-hrz-cb03.mfbhosp.org¨∆Jœ
-
-view.mfbhosp.org¨∆Jœ
-
-crdl.orgeKœ
-
-simbridge.baycollege.eduñRKœ
- 
-www.campus.ccsdetroit.edu!√Jœ
-
-campus.ccsdetroit.edu!√Jœ
-
-crdl.orgeKœ
-
-hackleylibrary.mi.3cx.usºrJœ
-
-ds.training.incommon.org'§Kœ
-
-gaylord.k12.mi.us%ßJœ
-
-icsenforcer.com®qKœ
-(
-!sma.collegeforcreativestudies.edu6√Jœ
-)
-"auth.collegeforcreativestudies.edu8√Jœ
-
-mail.merit.eduΩtKœ
-
-mbg.hillmanschools.commRJœ
-
-	remc1.net5Kœ
-(
-!web.collegeforcreativestudies.edu(√Jœ
-
-crdl.orgeKœ
-
-luna.ccsdetroit.edu»√Jœ
-
-voice.nemcworks.org¢cKœ
-(
-!merit-pdreceiver-prod01.merit.eduftKœ
-0
-)selfservice.collegeforcreativestudies.edu,√Jœ
-
-hillsdale.edu(ÍKœ
-"
-merit-hscc-prod01.merit.eduVtKœ
-4
--wmcc-kalamazoo-wired-wprnkcgvzm.dynamic-m.comSqKœ
-*
-#omeka.collegeforcreativestudies.edu7√Jœ
-
-www.helpdesk.tln.orgÙ¢Kœ
-$
-collegeforcreativestudies.edu(√Jœ
-
-helpdesk.tln.orgÙ¢Kœ
-
-pdreceiver.merit.eduftKœ
-
-ra.nettKœ
-
-mfb-hrz-cb02.mfbhosp.org¨∆Jœ
-
-	remc1.net?Kœ
-
-catalog.tln.lib.mi.us°Kœ
-
-hillsdale.eduNÍKœ
-"
-www.vpn.lvdhealthcenter.com\7Kœ
-
-sfdc-view02.merit.eduYtKœ
-
-idp.merit.edu uKœ
-
-www.acvpn.mfbhosp.orgÇ∆Jœ
-
-sfdc-view02.merit.eduYtKœ
-
-merit-idp01.merit.edu uKœ
-
-	merit.edu–tKœ
-
-auth.ccsdetroit.edu8√Jœ
- 
-autodiscover.alconahc.orgxMJœ
-
-hillsdale.eduWÍKœ
-
-hillsdale.edu=ÍKœ
-
-hillsdale.eduRÍKœ
-
-	merit.edu9uKœ
- 
-idp.training.incommon.org'§Kœ
-
-www.vpn.crystalfalls.org)Kœ
-
-eupschools.org”Kœ
-
-vpn.baycollege.edu:RKœ
-/
-(www.campus.collegeforcreativestudies.edu!√Jœ
-
-hillsdale.eduÍKœ
-.
-'expy-ford.collegeforcreativestudies.edu(√Jœ
-(
-!web.collegeforcreativestudies.edu(√Jœ
-
-	remc1.net∂¬Kœ
-
-stash.merit.edu¡tKœ
-
-attendanceondemand.com˙Kœ
-
-fg1a.ioscocounty.org"∫Kœ
-
-hillsdale.edu4ÍKœ
-
-hillsdale.edu`ÍKœ
-
-alpenaschools.comjOJœ
-
-hillsdale.edu0ÍKœ
-
-hillsdale.eduOÍKœ
-
-hillsdale.edu=ÍKœ
-
-hillsdale.eduRÍKœ
-%
-boardbook.nmu.edu2 H® íòí D
- 
-imap.nmu.edu2 H® íòí D
-!
-mail1.nmu.edu2 H® íòí D
-#
-myuser2.nmu.edu2 H® íòí a
-
-nic.nmu.edu2 H® íòí D
-#
-srvsweb.nmu.edu2 H® íòí D
-!
-myweb.nmu.edu2 H® íòí D
-#
-webmail.nmu.edu2 H® íòí I
-#
-arcmail.nmu.edu2 H® íòí D
-$
-webpages.nmu.edu2 H® íòí D
-"
-myusr1.nmu.edu2 H® íòí a
-"
-myuser.nmu.edu2 H® íòí a
-"
-myusr2.nmu.edu2 H® íòí a
-!
-rocky.nmu.edu2 H® íòí I
-#
-regtest.nmu.edu2 H® íòí D
-%
-roundcube.nmu.edu2 H® íòí I
-
-pop.nmu.edu2 H® íòí D
-%
-wolverine.nmu.edu2 H® íòíB
-%
-mailshare.nmu.edu2 H® !ôòô 
-$
-listserv.nmu.edu2 H® !ôòô 
-"
-lstsrv.nmu.edu2 H® !ôòô 
-"
-beaker.nmu.edu2 H® !ôòô 
-#
-mlshare.nmu.edu2 H® !ôòô 
-!
-mlist.nmu.edu2 H® !ôòô 
-"
-nmuebs.nmu.edu2 H® !ôòô 
-"
-ittech.nmu.edu2 H® !ôòô 
-"
-muninn.nmu.edu2 H® !ôòô 
-&
-enterprise.nmu.edu2 H® !ôòô 1
-#
-imginfo.nmu.edu2 H® !ôòô 
-"
-icinga.nmu.edu2 H® !ôòô 
-"
-pigpen.nmu.edu2 H® !ôòô 
-%
-kenny.acs.nmu.edu2 H® !ôòô 
-!
-kenny.nmu.edu2 H® !ôòô 
-&
-enterprise.nmu.edu2 H® !ôòô 
-!
-munin.nmu.edu2 H® !ôòô 
-"
-moonin.nmu.edu2 H® !ôòô 
-#
-imginfo.nmu.edu2 H® !ôòô 1
-"
-ittech.nmu.edu2 H® !ôòô 1
-"
-nmuebs.nmu.edu2 H® !ôòô 1
-"
-pigpen.nmu.edu2 H® !ôòô 1
-%
-catalysts.nmu.edu2 H® !ôòô A
-%
-blogs.acs.nmu.edu2 H® !ôòô A
-#
-lovejoy.nmu.edu2 H® !ôòô A
-#
-www.acs.nmu.edu2 H® !ôòô A
-$
-wiki.acs.nmu.edu2 H® !ôòô A
-
-
-it.nmu.edu2 H® !ôòô A
-"
-hdwiki.nmu.edu2 H® !ôòô A
- 
-apps.nmu.edu2 H® !ôòô q
-$
-notebook.nmu.edu2 H® !ôòô Y
-$
-wildcast.nmu.edu2 H® !ôòô i
-"
-educat.nmu.edu2 H® "ò 
-$
-devapply.nmu.edu2 H® !ôòô r
-!
-apply.nmu.edu2 H® !ôòô p
-"
-ike2jj.nmu.edu2 H® "ò !
-$
-internal.nmu.edu2 H® !ôòô q
- 
-ike2.nmu.edu2 H® "ò !
-*
-devorientation.nmu.edu2 H® !ôòô r
-"
-ike2km.nmu.edu2 H® "ò !
-#
-charlie.nmu.edu2 H® 2 ò  
-(
-nmudrivetest.nmu.edu2 H® 2 r  
-
-
-d7.nmu.edu2 H® 2 ò  
-
-www.nmu.edu2 H® 2 ò  
-%
-alexander.nmu.edu2 H® 2 r  
-%
-dev.nmu-media.com2 H® 2 ò  
-&
-maap.nmu-media.com2 H® 2 ò  
- 
-webb.nmu.edu2 H® 2 ò  
-&
-photo.up200nmu.com2 H® 2 ò  
-!
-nmu-media.com2 H® 2 ò  
- 
-up200nmu.com2 H® 2 ò  
-'
-photo.nmu-media.com2 H® 2 ò  
-%
-dev.nmu-media.org2 H® 2 ò  e
-
-maap.org2 H® 2 ò  
-
-idp.nmu.edu2 H® 2 ò  I
-#
-marbles.nmu.edu2 H® 2 ò  
-
-dev.nmu.edu2 H® 2 ò  e
-&
-foundation.nmu.edu2 H® 2 ò  e
-,
-foundation.nmu-media.org2 H® 2 ò  e
-$
-franklin.nmu.edu2 H® 2 ò  e
-&
-news.nmu-media.org2 H® 2 ò  e
-
-nmu.edu2 H® 2 ò  e
-&
-alexandria.nmu.edu2 H® 2 ò  
-!
-nmu-media.org2 H® 2 ò  e
- 
-news.nmu.edu2 H® 2 ò  e
-"
-mytest.nmu.edu2 H® 2 ò 
-$
-nmudrive.nmu.edu2 H® 2 ò  
-#
-umcdev1.nmu.edu2 H® 2òq
-'
-umcdev1-dev.nmu.edu2 H® 2òq
-!
-mynmu.nmu.edu2 H® 2 ò %
-
-leo.nmu.edu2 H® 2 ò 
-"
-cmssso.nmu.edu2 H® 2 ò D
-#
-umcdev2.nmu.edu2 H® 2òr
-.
-umcdev1-foundation.nmu.edu2 H® 2òq
-(
-umcdev1-news.nmu.edu2 H® 2òq
-
-nmu.college2 H® 2òq
-#
-umcdev3.nmu.edu2 H® 2òs
-#
-umcdev4.nmu.edu2 H® 2òó
-$
-capsrv.aglt2.org2 H®h˜ í A0E
-&
-psumvm02.aglt2.org2 H®h˜ í A1 B
-%
-maddash.aglt2.org2 H®h˜ í A1
-&
-psumvm01.aglt2.org2 H®h˜ í A1 E
-2
-meshconfig.opensciencegrid.org2 H®h˜Äí A6
-"
-psdb.aglt2.org2 H®h˜ í A1G
--
-psmad.opensciencegrid.org2 H®h˜ í A1
-&
-psconfig.aglt2.org2 H®h˜Äí A6
-0
-psconfig.opensciencegrid.org2 H®h˜Äí A6
-)
-aaof-gw-fin.merit.edu2 H®hÄ        
-,
-aaof-gw-netops.merit.edu2 H®hÄ        #
-)
-aaof-gw-msc.merit.edu2 H®hÄ        $
-$
-domreg.merit.edu2 H®hÄ h    
-+
-aaof-gw-staff.merit.edu2 H®hÄ        
-&
-alexandria.nmu.edu2 H® 2 ò  
-+
-aaof-gw-swdev.merit.edu2 H®hÄ        
-)
-aaof-gw-sec.merit.edu2 H®hÄ        
-
-
-domreg.org2 H®hÄ h    
-!
-cus.wayne.edu2&ó B      ´Õ
-1
-merit-domreg-prod01.merit.edu2 H®hÄ h    
-
-www.nmu.edu2 H® 2 ò  
-!
-eng.wayne.edu2&ó B      ´Õ
-!
-mail1.nmu.edu2 H® íòí D
-$
-franklin.nmu.edu2 H® 2 ò  e
- 
-ike2.nmu.edu2 H® "ò !
-"
-educat.nmu.edu2 H® "ò 
-$
-franklin.nmu.edu2 H® 2 ò  e
-
-idp.nmu.edu2 H® 2 ò  I
-%
-kenny.acs.nmu.edu2 H® !ôòô 
-"
-beaker.nmu.edu2 H® !ôòô 
-
-leo.nmu.edu2 H® 2 ò 
- 
-ike2.nmu.edu2 H® "ò !
-!
-mail1.nmu.edu2 H® íòí D
-$
-capsrv.aglt2.org2 H®h˜ í A0E
-
-www.nmu.edu2 H® 2 ò  
-#
-marbles.nmu.edu2 H® 2 ò  
-!
-mail1.nmu.edu2 H® íòí D
-"
-pigpen.nmu.edu2 H® !ôòô 
-*
-merit-jira02.merit.edu2 H®hÄ h    ë
- 
-ike2.nmu.edu2 H® "ò !
-"
-pigpen.nmu.edu2 H® !ôòô 
-/
-michiganbroadbandsummit.org2 H®hÄ h     
-$
-franklin.nmu.edu2 H® 2 ò  e
-)
-merit-idp01.merit.edu2 H®hÄ h       
-%
-kenny.acs.nmu.edu2 H® !ôòô 
-
-nmu.edu2 H® 2 ò  e
-*
-merit-jira02.merit.edu2 H®hÄ h    ë
-
-irr.net2 H®hÄ h      
-)
-merit-idp01.merit.edu2 H®hÄ h       
-5
-!merit-pdreceiver-test01.merit.edu2 H®hÄ h    
-/
-merit-hscc-prod01.merit.edu2 H®hÄ h     Ü
-!
-mail1.nmu.edu2 H® íòí D
-"
-psdb.aglt2.org2 H®h˜ í A1G
-(
-michiganmoonshot.org2 H®hÄ h     
-)
-origin1.internet2.edu2 h&          "
-1
-merit-domreg-prod01.merit.edu2 H®hÄ h    
-)
-origin1.internet2.edu2 h&          "
-/
-michiganbroadbandsummit.net2 H®hÄ h     
-%
-kenny.acs.nmu.edu2 H® !ôòô 
-9
-%nso-sandbox-dev.macc.ns.internet2.edu2 h&·       Å
-!
-mynmu.nmu.edu2 H® 2 ò %
-&
-psconfig.aglt2.org2 H®h˜Äí A6
-
-leo.nmu.edu2 H® 2 ò 
-&
-alexandria.nmu.edu2 H® 2 ò  
-/
-michiganbroadbandsummit.com2 H®hÄ h     
-%
-protect.wayne.edu2&ó /Ú       
-!
-mail1.nmu.edu2 H® íòí D
-$
-franklin.nmu.edu2 H® 2 ò  e
-/
-merit-bitbucket02.merit.edu2 H®hÄ h    ì
-5
-!merit-pdreceiver-prod01.merit.edu2 H®hÄ h    
-&
-psumvm01.aglt2.org2 H®h˜ í A1 E
-(
-michiganmoonshot.net2 H®hÄ h     
-&
-psconfig.aglt2.org2 H®h˜Äí A6
-&
-psconfig.aglt2.org2 H®h˜Äí A6
-"
-pigpen.nmu.edu2 H® !ôòô 
-&
-psumvm02.aglt2.org2 H®h˜ í A1 B
-
-	umich.edu2&         
-%
-maddash.aglt2.org2 H®h˜ í A1
-!
-mail1.nmu.edu2 H® íòí D
-%
-maddash.aglt2.org2 H®h˜ í A1
-!
-rocky.nmu.edu2 H® íòí I
-%
-kenny.acs.nmu.edu2 H® !ôòô 
-!
-mail1.nmu.edu2 H® íòí D
-%
-kenny.acs.nmu.edu2 H® !ôòô 
-!
-vpn.merit.edu2 H®hÄ        
-/
-merit-bitbucket02.merit.edu2 H®hÄ h    ì
-(
-michiganmoonshot.com2 H®hÄ h     
-!
-rocky.nmu.edu2 H® íòí I
-#
-umcdev1.nmu.edu2 H® 2òq
-!
-mail1.nmu.edu2 H® íòí D
-#
-umcdev4.nmu.edu2 H® 2òó
-#
-umcdev2.nmu.edu2 H® 2òr
-!
-rocky.nmu.edu2 H® íòí I
-#
-umcdev1.nmu.edu2 H® 2òq
-1
-merit-domreg-prod01.merit.edu2 H®hÄ h    
-5
-!merit-pdreceiver-prod01.merit.edu2 H®hÄ h    
-
-	wayne.edu2&ó B      ´Õ
-#
-umcdev1.nmu.edu2 H® 2òq
-%
-wolverine.nmu.edu2 H® íòíB
-#
-umcdev1.nmu.edu2 H® 2òq
-=
-)nso-sandbox-testing.macc.ns.internet2.edu2 h&·       Ç
-#
-umcdev3.nmu.edu2 H® 2òs
-
-www.nmu.edu2 H® 2 ò  
-
-
-domreg.org2 H®hÄ h    
-!
-mail1.nmu.edu2 H® íòí D
-1
-merit-domreg-prod01.merit.edu2 H®hÄ h    
-
-
-domreg.org2 H®hÄ h    
-,
-www.michiganmoonshot.com2 H®hÄ h     
-!
-www.umich.edu2&         
-,
-www.michiganmoonshot.net2 H®hÄ h     
-,
-www.michiganmoonshot.org2 H®hÄ h     
-
-www.nmu.edu2 H® 2 ò  
-*
-washtenawbroadband.org2 H®hÄ h     
-.
-www.washtenawbroadband.org2 H®hÄ h     
-
-tlstest.vpnalyzer.com}{‘ç
-
-meow.vpnalyzer.com2{‘ç
-
-tlstest.vpnalyzer.comÖ{‘ç
-
-tlstest.vpnalyzer.comÄ{‘ç
-
-tlstest.vpnalyzer.comÑ{‘ç
-
-tlstest.vpnalyzer.comÜ{‘ç
-
-bark.vpnalyzer.com0{‘ç
-
-tlstest.vpnalyzer.com}{‘ç
-
-tlstest.vpnalyzer.comÅ{‘ç
-
-tlstest.vpnalyzer.com~{‘ç
-
-loc.vpnalyzer.net◊{‘ç
-
-loc.vpnalyzer.net⁄{‘ç
-
-loc.vpnalyzer.netŸ{‘ç
-
-loc.vpnalyzer.net‹{‘ç
-
-loc.vpnalyzer.net€{‘ç
-
-loc.vpnalyzer.netÿ{‘ç
-
-psr.vpnalyzer.com·{‘ç
-
-loc.vpnalyzer.net›{‘ç
-
-loc.vpnalyzer.netﬁ{‘ç
-
-loc.vpnalyzer.net‡{‘ç
-
-psr.vpnalyzer.com‚{‘ç
-
-psr.vpnalyzer.com„{‘ç
-
-psr.vpnalyzer.com‰{‘ç
-
-psr.vpnalyzer.comÂ{‘ç
-
-psr.vpnalyzer.comÊ{‘ç
-
-psr.vpnalyzer.comÍ{‘ç
-
-psr.vpnalyzer.comË{‘ç
-
-psr.vpnalyzer.comÈ{‘çë	$
- ”
-ãñ¥a8ºõf)"F¬“™25Í1*)[&˜CZ"à
-7
-141.219.0.0/1635.8.0.0/162001:48a8:5fe0::1/64 
-à
-192.122.184.0/24192.203.195.0/24192.88.242.0/24192.41.229.0/24206.201.157.0/24192.35.168.0/232001:48a8:5fe0:0001::1/64
-#128.138.0.0/162620:18f::/32
-,35.8.0.0/242001:48a8:5fe0:0002::1/64
-E
-192.122.190.0/242001:48a8:687f:2::/642001:48a8:7fff:b::2/64
-(35.6.0.0/162001:48a8:687f:2::/64 *$
- °Àóæi|^’Æ˝xˇ§€~h$`5‰
-âï¡XÄqwZ2öhttps://1.1.1.1/dns-queryr.refraction.network" °Àóæi|^’Æ˝xˇ§€~h$`5‰
-âï¡XÄqw*$3*Firefox_65,1*Firefox_63,1*iOS_12_12stun.voip.blackberry.com:3478

--- a/tools/clientconf/1169
+++ b/tools/clientconf/1169
@@ -1,0 +1,7850 @@
+
+éﬁ
+
+epibio.msu.edu|#
+
+httpd.sip.msu.eduw#
+
+www.law.msu.eduŒ#
+
+aris.rad.msu.edu»†#
+
+glccn.iwr.msu.edupy#
+
+pathobiology.msu.edu¯–#
+
+svn.cvm.msu.edu∑–#
+
+tic9.lib.msu.eduﬂ#
++
+$officeonline01.intranet.nscl.msu.edu2 #
+
+stash.frib.msu.edu`!#
+
+locate.lib.msu.eduﬂ#
+
+radzfp01.rad.msu.edu»ü#
+
+pro2.educ.msu.eduà©#
+
+maps.gmsts.org #
+
+websvcs.lib.msu.eduﬂ#
+
+www.misin.msu.edu #
+
+enterprise.frib.msu.edu`!#
++
+$officeonline02.intranet.nscl.msu.edu2 #
+
+gsrpdf.lib.msu.eduﬂ#
+
+afrjpdf.lib.msu.eduﬂ#
+
+maps.asets.msu.edu #
+
+copycenter.educ.msu.eduà©#
+
+www.dcpah.msu.edu¯–#
+
+envlit.educ.msu.eduà©#
+
+glccn.iwr.msu.eduoy#
+&
+enterprise-worker4.nscl.msu.edu"#
+
+mmm.lib.msu.eduCﬂ#
+
+library.msu.eduTﬂ#
+
+www.loncapa.msu.eduÈd#
+
+tribuneentry.lib.msu.eduﬂ#
+
+smgr1.sip.msu.eduw#
+
+www.hub.msu.eduKﬂ#
+
+lhfacility.msu.edu#
+
+gateway.frib.msu.edu`!#
+
+wjxg.lib.msu.eduKﬂ#
+
+help.nscl.msu.eduî##
+(
+!xenapp-sf01.intranet.nscl.msu.eduv #
+
+publicapps.nscl.msu.edu® #
+
+slikerentry.lib.msu.eduﬂ#
+
+www.asets.msu.edu #
+
+tic.lib.msu.eduTﬂ#
+
+orlab.educ.msu.eduà©#
+
+login.lib.msu.eduTﬂ#
+
+dpps.msu.edu#
+
+smgr2.sip.msu.eduw#
+
+sip.msu.edux#
+
+pdfproc.lib.msu.eduﬂ#
+
+agbib.lib.msu.edu>ﬂ#
+
+www.epicedpolicy.msu.eduà©#
+
+publicapps.frib.msu.edu® #
+
+gateway01.frib.msu.edu`!#
+
+userportal.frib.msu.edu`!#
+
+gateway01.nscl.msu.edu`!#
+
+grassius.org…ò#
+$
+www.mttc-process.educ.msu.eduà©#
+
+www.new.law.msu.eduŒ#
+
+servu.usd.msu.edu&5#
+
+enviroimpact.iwr.msu.eduoy#
+
+gateway.frib.msu.eduî##
+
+new.law.msu.eduŒ#
+
+smgr2.sip.msu.edux#
+
+radzfp01.rad.msu.edu»ü#
+
+docs.slowthespread.org2 #
+
+smgr1.sip.msu.edux#
+
+enterprise.nscl.msu.eduî##
+
+lib.msu.eduﬂ#
+
+www.orlab.educ.msu.eduà©#
+
+gis.iwr.msu.eduiy#
+ 
+officeonline.frib.msu.edu2 #
+
+stash.frib.msu.eduî##
+"
+officeonline01.frib.msu.edu2 #
+
+help.frib.msu.eduî##
+ 
+dotnet-ext01.frib.msu.edu® #
+
+www.pathobiology.msu.edu¯–#
+"
+aquaticanimalhealth.msu.edu¯–#
+!
+www.compstrat.educ.msu.eduà©#
+
+usd-svr108.usd.msu.edu&5#
+ 
+mttc-process.educ.msu.eduà©#
+
+smgr1.sip.msu.edux#
+
+publicapps.nscl.msu.edu"#
+
+tic.msu.eduTﬂ#
+
+dcpah.msu.edu¯–#
+
+dpps.msu.edu#
+
+servu.usd.msu.edu&5#
+
+loncapa.msu.eduÈd#
+
+enterprise.frib.msu.eduî##
+
+compstrat.educ.msu.eduà©#
+
+s5.lite.msu.eduÌd#
+
+publicapps.frib.msu.edu"#
+
+globalfood.law.msu.eduŒ#
+
+m.lib.msu.eduTﬂ#
+
+www.tic.msu.eduTﬂ#
+
+vss1.loncapa.msu.eduÚd#
+)
+"officeonline.intranet.nscl.msu.edu2 #
+
+accounts.frib.msu.eduv #
+
+smgr1.sip.msu.eduw#
+
+agris-knowledgebase.org–ò#
+
+wapp.cvm.msu.edu∑–#
+
+www.cvm.msu.edu¯–#
+
+s1.lite.msu.eduÂd#
+
+appscb.frib.msu.eduv #
+
+zendesk.police.msu.eduY#
+
+fuzzy.asets.msu.edu	 #
+
+www.envlit.educ.msu.eduà©#
+
+httpd.sip.msu.edux#
+
+sip.msu.eduw#
+
+metadata.lib.msu.edu)ﬂ#
+
+animalhealth.msu.edu¯–#
+
+sip.msu.edux#
+
+wbh12.geo.msu.eduD#
+
+xenapp-sf02.frib.msu.eduv #
+
+apps.frib.msu.eduv #
+
+httpd.sip.msu.edux#
+
+vethospital.cvm.msu.edu¯–#
+!
+www.journalofexpertise.org>0#
+!
+digitalcommons.law.msu.eduŒ#
+
+httpd.sip.msu.eduw#
+
+lon-capa.msu.eduÈd#
+
+userportal.frib.msu.eduî##
+
+xenapp-sf01.frib.msu.eduv #
+
+interlib.lib.msu.eduﬂ#
+
+apps.nscl.msu.eduv #
+
+aclgoals.educ.msu.eduà©#
+
+smgr2.sip.msu.edux#
+"
+www.vethospital.cvm.msu.edu¯–#
+
+swamplr.lib.msu.edu]ﬂ#
+ 
+dotnet-ext02.frib.msu.edu® #
+
+avida-ed.msu.edu†§#
+"
+officeonline02.frib.msu.edu2 #
+&
+www.aquaticanimalhealth.msu.edu¯–#
+
+teachingcenter.msu.eduKﬂ#
+
+d.lib.msu.edu]ﬂ#
+
+lib.msu.eduTﬂ#
+
+gds.lib.msu.edu’ﬂ#
+"
+www.copycenter.educ.msu.eduà©#
+
+gateway01.nscl.msu.eduî##
+&
+enterprise-worker4.frib.msu.edu"#
+
+www.lon-capa.msu.eduÈd#
+
+s2.lite.msu.eduÊd#
+#
+blast.grassius.eglab-dev.com ò#
+
+gis2.iwr.msu.eduèy#
+
+parking.msu.edu#
+
+gateway01.frib.msu.eduî##
+
+epicedpolicy.msu.eduà©#
+
+blogs.lib.msu.eduTﬂ#
+
+sip.msu.eduw#
+
+help.nscl.msu.edu`!#
+
+lists.psy.msu.edu0#
+
+portal.frib.msu.edu`!#
+
+repo-web.lib.msu.edu]ﬂ#
+
+www.animalhealth.msu.edu¯–#
+)
+"accessibility-intranet.lib.msu.eduÀﬂ#
+
+usd-svr108.usd.msu.edu&5#
+
+mainweb7.lib.msu.eduTﬂ#
+!
+mail.ghalibconcordance.orgh‡#
+
+codeprod.lib.msu.edu#
+
+vmhc.lib.msu.eduÀﬂ#
+
+calendar.cal.msu.edu™‡#
+
+c4i.msu.edu™‡#
+
+illiad3.lib.msu.eduﬂ#
+
+dmhsp.lib.msu.edu]ﬂ#
+
+ctli.lib.msu.eduKﬂ#
+
+wbh02.geo.msu.edu#
+
+testing.elc.msu.edu}‡#
+
+blogpublic.lib.msu.eduTﬂ#
+
+acm.cal.msu.edu™‡#
+
+s7.lite.msu.eduÔd#
+
+toneperfect.lib.msu.edu]ﬂ#
+
+mainweb9.lib.msu.eduﬂ#
+ 
+accessibleart.cal.msu.edu™‡#
+
+cofad.cal.msu.edu™‡#
+
+ippsr.msu.eduG#
+
+mail.shtisel-diary.orgh‡#
+
+urires.lib.msu.eduÀﬂ#
+
+mail.clear.msu.eduh‡#
+
+tone.lib.msu.edu]ﬂ#
+
+spc.lib.msu.eduÀﬂ#
+
+ingest.lib.msu.edu]ﬂ#
+
+csapp.cal.msu.edu™‡#
+
+mail.llc.msu.eduh‡#
+
+blast.camregbase.orgŒò#
+!
+mail.ghalibconcordance.orgh‡#
+
+woci.cal.msu.edu™‡#
+
+ticmag.lib.msu.edu]ﬂ#
+
+sentinelws.msu.edu%0	#
+
+cms02.cascade.msu.eduÃ
+	#
+
+tone-legacy.lib.msu.edu]ﬂ#
+
+reservations.lib.msu.eduÀﬂ#
+
+mail.elc.msu.eduh‡#
+ 
+education2035.cal.msu.edu™‡#
+
+socialmedia.msu.edu&0	#
+#
+moria-jupyterhub.egr.msu.eduì%	#
+
+ojs.msupress.msu.eduàﬂ#
+
+deans.msu.edu™‡#
+
+gateway.nscl.msu.edu`!#
+
+deansreport.cal.msu.edu™‡#
+
+mail.shtisel-diary.orgh‡#
+
+mail.mi-diaries.orgh‡#
+
+grange.lib.msu.edu]ﬂ#
+
+packstore.lib.msu.eduÀﬂ#
+
+mail.elc.msu.eduh‡#
+
+d-legacy.lib.msu.edu]ﬂ#
+
+mail.mi-diaries.orgh‡#
+(
+!xenapp-sf02.intranet.nscl.msu.eduv #
+
+er.lib.msu.eduÀﬂ#
+
+etd.lib.msu.edu]ﬂ#
+
+ticpass.lib.msu.eduÀﬂ#
+
+mail.camps.cal.msu.eduh‡#
+
+www.lib.msu.eduÀﬂ#
+
+rt.hpcc.msu.eduó	#
+
+muses.cal.msu.edu™‡#
+
+xa.cal.msu.edu™‡#
+
+globalsafety.msu.eduD0	#
+
+webapp.cvm.msu.edu∑–#
+
+mail.celta.msu.eduh‡#
+
+marcom.cal.msu.edu™‡#
+
+mail.sls.msu.eduh‡#
+
+elc.msu.edu™‡#
+
+dock.matrix.msu.edu 	#
+
+cse.msu.edu	#
+
+mail.h-net.org	#
+
+pressojs.lib.msu.eduàﬂ#
+
+globalyouth.isp.msu.eduD0	#
+
+osimis.egr.msu.eduì%	#
+
+foglio.cal.msu.edu™‡#
+
+files.cal.msu.eduM‡#
+
+sepos.cal.msu.edu™‡#
+
+repo.lib.msu.edu]ﬂ#
+
+git.egr.msu.eduõ%	#
+
+oirc.msu.eduD0	#
+
+mail.shtisel-diary.orgh‡#
+
+maflt.cal.msu.edu™‡#
+
+j1scholar.ais.msu.eduD0	#
+
+misc.lib.msu.eduÀﬂ#
+
+ojs-web.msupress.orgàﬂ#
+
+spcrequest.lib.msu.eduèﬂ#
+
+gitlab.matrix.msu.edu 	#
+
+dhlc.cal.msu.edu™‡#
+
+mail.camps.cal.msu.eduh‡#
+
+yagi.h-net.org(	#
+
+kylewhyte.cal.msu.edu™‡#
+
+commdeptreview.msu.edu/0	#
+
+www.events.msu.eduJ0	#
+
+events.msu.eduJ0	#
+
+www.sentinelws.msu.edu%0	#
+
+tcb.lib.msu.edu’ﬂ#
+
+chat.matrix.msu.edu 	#
+
+rindexer.lib.msu.edu]ﬂ#
+
+mail.mi-diaries.orgh‡#
+ 
+annualreports.ipf.msu.eduX0	#
+
+web6.cal.msu.edu´‡#
+
+hamilton.h-net.org	#
+
+muse.cal.msu.edu™‡#
+
+mail.clear.msu.eduh‡#
+
+mail.shtisel-diary.orgh‡#
+
+mail.celta.msu.eduh‡#
+%
+slimgpu-jupyterhub.egr.msu.eduì%	#
+
+mail.mi-diaries.orgh‡#
+
+mail.llc.msu.eduh‡#
+
+cats.h-net.orgÙ	#
+
+blazar.egr.msu.edu=%	#
+
+lists.h-net.org	#
+
+michilac.lib.msu.edu]ﬂ#
+#
+docstatus.itservices.msu.edu0	#
+
+rdsvdi-cb1.egr.msu.eduË%	#
+
+mail.clear.msu.eduh‡#
+
+intranet.lib.msu.eduÄﬂ#
+
+web.cal.msu.edu™‡#
+
+www.c4i.msu.edu™‡#
+
+www.egr.msu.edu>%	#
+
+remote.egr.msu.eduË%	#
+
+wide.cal.msu.edu™‡#
+
+mail.llc.msu.eduh‡#
+
+mail.elc.msu.eduh‡#
+
+web5.cal.msu.edu™‡#
+
+comreview.msu.edu00	#
+ 
+intranet-prod.lib.msu.eduÄﬂ#
+
+copyright.lib.msu.eduÀﬂ#
+
+cse.msu.edu	#
+
+vetp.isp.msu.eduD0	#
+
+cse.msu.eduŸ	#
+
+yagi.h-net.org(	#
+
+mail.sls.msu.eduh‡#
+
+vipp.isp.msu.eduD0	#
+ 
+rdsvdi-webgw2.egr.msu.eduË%	#
+
+egr.msu.edu>%	#
+
+fuse.cal.msu.edu™‡#
+
+rds.egr.msu.eduË%	#
+
+smtp.campusad.msu.edui0	#
+
+mirrors.egr.msu.eduí%	#
+
+www.clacs.isp.msu.eduD0	#
+$
+turing-jupyterhub.egr.msu.eduì%	#
+
+contact.icer.msu.eduá	#
+
+olin.msu.eduK0	#
+
+listings.lib.msu.eduñﬂ#
+
+mail.clear.msu.eduh‡#
+
+globalyouth.msu.eduD0	#
+ 
+server-status.lib.msu.eduÀﬂ#
+
+hamilton.h-net.org	#
+
+egr.msu.edu<%	#
+!
+beta.ondemand.hpcc.msu.eduÉ	#
+
+mail.camps.cal.msu.eduh‡#
+
+oihs.isp.msu.eduD0	#
+
+mail.shtisel-diary.orgh‡#
+
+mail.camps.cal.msu.eduh‡#
+
+dossier.lib.msu.edu›ﬂ#
+
+mail.llc.msu.eduh‡#
+
+hybrid.campusad.msu.edui0	#
+
+mail.h-net.org	#
+
+git.lib.msu.eduÀﬂ#
+
+clacs.msu.eduD0	#
+!
+mail.ghalibconcordance.orgh‡#
+
+khalil.cal.msu.edu™‡#
+
+repropedia.comì0	#
+
+mail.celta.msu.eduh‡#
+
+globalsafety.isp.msu.eduD0	#
+
+globalafrica.isp.msu.eduD0	#
+
+www.oihs.msu.eduD0	#
+#
+dev.globalsafety.isp.msu.eduD0	#
+!
+mail.ghalibconcordance.orgh‡#
+
+mail.celta.msu.eduh‡#
+
+mail.mi-diaries.orgh‡#
+
+pscd.msu.eduD0	#
+!
+jupyterhub-gpu.egr.msu.eduì%	#
+
+www.oihs.isp.msu.eduD0	#
+
+broker.egr.msu.eduË%	#
+
+oirc.isp.msu.eduD0	#
+
+jupyterhub.egr.msu.eduì%	#
+
+vpn-rsc.egr.msu.eduÏ$	#
+
+analytics.h-net.orgK	#
+"
+achievements.webapp.msu.edu{0	#
+
+www.globalafrica.msu.eduD0	#
+
+vetp.msu.eduD0	#
+
+vis.itservices.msu.edu20	#
+
+rdsvdi-cb2.egr.msu.eduË%	#
+#
+demo.framework.comms.msu.edux0	#
+
+concussion.msu.eduá0	#
+
+www.clacs.msu.eduD0	#
+
+snapp.rad.msu.eduá0	#
+
+www.comms.msu.edu&0	#
+
+oihs.msu.eduD0	#
+&
+www.tanzaniapartnership.msu.eduD0	#
+
+film.msu.edu™‡#
+
+reprotopia.msu.eduì0	#
+"
+jupyterhub-test.egr.msu.eduì%	#
+
+clacs.isp.msu.eduD0	#
+
+mail.elc.msu.eduh‡#
+#
+cad-ex19-01.campusad.msu.edui0	#
+
+anatomy.msu.eduá0	#
+
+www.egr.msu.edu<%	#
+
+mail.elc.msu.eduh‡#
+#
+cad-ex19-03.campusad.msu.edui0	#
+ 
+www.concussionimaging.comá0	#
+
+mail.sls.msu.eduh‡#
+
+oiss.isp.msu.eduD0	#
+"
+religioussounds.cal.msu.edu™‡#
+#
+cad-ex19-02.campusad.msu.edui0	#
+$
+jupyterhub-grader.egr.msu.eduì%	#
+
+dfsca.msu.eduJ0	#
+#
+cad-ex16-01.campusad.msu.edui0	#
+
+education.rad.msu.eduá0	#
+
+tedx.obgyn.msu.eduì0	#
+$
+jupyterhub-legacy.egr.msu.eduì%	#
+
+vipp.msu.eduD0	#
+
+mail.campusad.msu.edui0	#
+
+stage.comms.msu.edux0	#
++
+$coursecompute-jupyterhub.egr.msu.eduì%	#
+
+www.vipp.isp.msu.eduD0	#
+
+youthempowerment.msu.eduD0	#
+
+www.pscd.isp.msu.eduD0	#
+
+pscd.isp.msu.eduD0	#
+
+globalideas.isp.msu.eduD0	#
+'
+ www.youthempowerment.isp.msu.eduD0	#
+#
+cad-ex16-04.campusad.msu.edui0	#
+
+bootcamp.msu.eduJ0	#
+
+riker.egr.msu.eduì%	#
+&
+cerberus-jupyterhub.egr.msu.eduì%	#
+
+qual.mdid.art.msu.edud0	#
+
+econ.msu.edui0	#
+
+www.rad.msu.eduá0	#
+
+www.vetp.msu.eduD0	#
+
+vpn.egr.msu.eduÏ$	#
+
+www.vetp.isp.msu.eduD0	#
+
+public.api.msu.eduR0	#
+
+community.idm.msu.edu*0	#
+#
+cad-ex19-04.campusad.msu.edui0	#
+
+www.pscd.msu.eduD0	#
+#
+www.youthempowerment.msu.eduD0	#
+ 
+autodiscover.cabs.msu.edui0	#
+
+autodiscover.msu.edui0	#
+*
+#www.tanzaniapartnership.isp.msu.eduD0	#
+
+matrix.msu.edu#	#
+!
+www.commdeptreview.msu.edu/0	#
+#
+cad-ex16-02.campusad.msu.edui0	#
+
+www.radiology.msu.eduá0	#
+ 
+myoiss.itservices.msu.eduN0	#
+$
+savemyfertility.obgyn.msu.eduì0	#
+
+www.woodrufflab.orgì0	#
+
+www.keyring.bric.msu.edu{	#
+
+www.rehab.msu.eduá0	#
+#
+www.globalsafety.isp.msu.eduD0	#
+
+www.bootcamp.msu.eduJ0	#
+#
+cad-ex16-03.campusad.msu.edui0	#
+
+sportsnutrition.msu.eduá0	#
+
+law.msu.edui0	#
+
+www.snapp.msu.eduá0	#
+#
+www.globalafrica.isp.msu.eduD0	#
+!
+hit-filemakerwb.hc.msu.eduE0	#
+"
+ipf-atcsprod.pplant.msu.edur0	#
+
+mls.chm.msu.edu
+	#
+
+www.sass.msu.eduÑ0	#
+
+research.rad.msu.eduá0	#
+
+www.msuhla.chm.msu.edu≥3	#
+
+menopause.obgyn.msu.eduì0	#
+
+wbp.rad.msu.eduá0	#
+
+oncofertility.msu.eduì0	#
+
+fw-ats.bric.msu.edu2{	#
+
+snapp.msu.eduá0	#
+
+rehab.msu.eduá0	#
+
+savemyeggs.orgì0	#
+
+www.socialmedia.msu.edu&0	#
+
+sass.msu.eduÑ0	#
+
+www.oirc.msu.eduD0	#
+
+savemyfertility.orgì0	#
+
+www.oiss.msu.eduD0	#
+
+timesheets.rad.msu.eduá0	#
+
+oiss.msu.eduD0	#
+
+woodrufflab.netì0	#
+
+autodiscover.ath.msu.edui0	#
+
+www.olin.msu.eduK0	#
+
+concussionimaging.comá0	#
+!
+womenshealth.obgyn.msu.eduì0	#
+
+msuoutreach.loncapa.orgîJ	#
+$
+autodiscover.campusad.msu.edui0	#
+
+www.savemyfertility.orgì0	#
+
+mail.msu.edui0	#
+
+www.globalsafety.msu.eduD0	#
+&
+tanzaniapartnership.isp.msu.eduD0	#
+ 
+beaumontcam.comms.msu.eduï0	#
+
+ath.msu.edui0	#
+
+www.dfsca.msu.eduJ0	#
+
+woodrufflab.orgì0	#
+
+savemyfertility.comì0	#
+
+msuhla.chm.msu.edu≥3	#
+
+brains.rad.msu.eduá0	#
+
+msuoutreach.lon-capa.orgîJ	#
+
+autodiscover.law.msu.edui0	#
+ 
+woodrufflab.obgyn.msu.eduì0	#
+"
+www.globalyouth.isp.msu.eduD0	#
+$
+phonequeuedisplay.rad.msu.eduá0	#
+
+db.msuhla.chm.msu.edu≥3	#
+
+www.repropedia.comì0	#
+
+www.concussion.msu.eduá0	#
+!
+msuphysicsclub.loncapa.orgîJ	#
+
+registry.gitlab.msu.edug0	#
+
+www.repropedia.orgì0	#
+!
+idp-sfp.itservices.msu.eduö0	#
+
+patient.rad.msu.eduá0	#
+
+beta.advancement.msu.edu™	#
+"
+msuphysicsclub.lon-capa.orgîJ	#
+
+myoiss.msu.eduN0	#
+
+repropedia.msu.eduì0	#
+
+monitor.loncapa.orgïJ	#
+
+www.oirc.isp.msu.eduD0	#
+ 
+www.concussionimaging.orgá0	#
+
+events.loncapa.orgñJ	#
+
+sportsmed.msu.eduá0	#
+
+concussionimaging.orgá0	#
+#
+www.apps.advancement.msu.edu™	#
+
+feig.bch.msu.eduÒa	#
+
+dev.mdid.art.msu.edud0	#
+
+testdrive.lite.msu.eduõJ	#
+
+s12.lite.msu.eduìJ	#
+
+researchcal.rad.msu.eduá0	#
+"
+www.sportsnutrition.msu.eduá0	#
+
+monitor.lon-capa.orgïJ	#
+
+fw-ats.bric.msu.edu{	#
+
+apps.advancement.msu.edu™	#
+ 
+webapp.msuhla.chm.msu.edu≥3	#
+ 
+secure.msuhla.chm.msu.edu≥3	#
+
+repropedia.orgì0	#
+
+www.beta.serve.msu.edu™	#
+
+fw-ats.bric.msu.edu
+{	#
+
+fw-ats.bric.msu.edu-{	#
+
+protegermifertilidad.comì0	#
+
+bps-s2.lite.msu.edu£J	#
+
+www.anatomy.msu.eduá0	#
+
+phonequeue.rad.msu.eduá0	#
+
+bps-s3.lite.msu.edu£J	#
+
+guardmyfertility.comì0	#
+
+www.brains.rad.msu.eduá0	#
+
+bps-s9.lite.msu.edu£J	#
+
+keyring.bric.msu.edu{	#
+
+isavefertility.orgì0	#
+
+beta.alumni.msu.edu™	#
+
+isavefertility.comì0	#
+
+savemyfertility.netì0	#
+
+monitor.lite.msu.eduïJ	#
+
+protectmyfertility.orgì0	#
+
+bps-s1.lite.msu.edu£J	#
+#
+www.beta.advancement.msu.edu™	#
+
+nls.uadv.msu.edu™	#
+
+beta.givingto.msu.edu™	#
+
+guardmyfertility.orgì0	#
+
+bps-s10.lite.msu.edu£J	#
+
+beta.advancement.msu.edu™	#
+
+outreach.lite.msu.eduîJ	#
+
+beta.alumni.msu.edu™	#
+
+dca.rad.msu.eduá0	#
+
+fw-ats.bric.msu.edu/{	#
+
+sandbox.lite.msu.eduúJ	#
+
+beta.serve.msu.edu™	#
+%
+www.spartanperformance.msu.eduá0	#
+
+sharepoint.ctsi.msu.edu{	#
+
+feig.bch.msu.eduÒa	#
+
+as400.rhs.msu.eduœº	#
+
+citrix.cvm.msu.edu=≥	#
+
+fm.ehs.msu.edu‹	#
+
+events.lon-capa.orgñJ	#
+!
+csctxns02.campusad.msu.edu&≥	#
+
+bric.msu.edu{	#
+
+rsgis-home.rsgis.msu.edu∆ˆ	#
+
+mibiomass.rsgis.msu.edu∆ˆ	#
+
+events.lite.msu.eduñJ	#
+&
+preservefertility.obgyn.msu.eduì0	#
+
+www.bric.msu.edu{	#
+ 
+www.beta.givingto.msu.edu™	#
+
+beta.givingto.msu.edu™	#
+
+www.beta.serve.msu.edu™	#
+ 
+cvmctx02.campusad.msu.edu=≥	#
+
+bps-s4.lite.msu.edu£J	#
+
+biopbprd.ebsp.msu.edu˜	#
+ 
+www.beta.givingto.msu.edu™	#
+
+citrix.cvm.msu.edu&≥	#
+
+www.beta.alumni.msu.edu™	#
+
+portal.ebsp.msu.edu˜	#
+ 
+dataservices.ebsp.msu.edu˜	#
+ 
+storefront.vetmed.msu.edu&≥	#
+
+analytics.bric.msu.edu{	#
+
+www.beta.alumni.msu.edu™	#
+%
+vmc-ctx-licens2.vetmed.msu.edu&≥	#
+
+inteum.icapps.msu.eduPw	#
+
+neuropsychology.msu.edu˜	#
+ 
+cvmctx02.campusad.msu.edu&≥	#
+!
+csctxsf01.campusad.msu.edu&≥	#
+
+fw-ats.bric.msu.edu{	#
+
+ntweb11.ais.msu.edu˜	#
+ 
+cvmctx01.campusad.msu.edu&≥	#
+
+rfid.msu.edu˜	#
+
+tools.ebsp.msu.edu˜	#
+
+xen.hit.msu.edu=≥	#
+
+fw-ats.bric.msu.edu9{	#
+
+jira.ebsp.msu.edu˜	#
+
+holmesqa.rhs.msu.eduœº	#
+
+fw-ats.bric.msu.edu"{	#
+
+ombudsman.msu.edu˜	#
+
+jboss.ebsp.msu.edu˜	#
+ 
+storefront.vetmed.msu.edu=≥	#
+
+beta.serve.msu.edu™	#
+
+xen.cvm.msu.edu&≥	#
+
+maps.rsgis.msu.edu∆ˆ	#
+!
+flintregistry.ctsi.msu.edu3{	#
+
+appmd.ais.msu.edu˜	#
+
+uas.rsgis.msu.edu∆ˆ	#
+
+fw-ats.bric.msu.edu#{	#
+
+web.cvm.msu.edu&≥	#
+
+qmsu00a.rhs.msu.eduœº	#
+
+www.webmail.bric.msu.edu{	#
+
+watsonqa.rhs.msu.eduœº	#
+
+dev.citrix.hit.msu.edu&≥	#
+
+secportal.ebsp.msu.edu˜	#
+
+dcpahonline.msu.edu&≥	#
+!
+csctxns01.campusad.msu.edu&≥	#
+
+qmsu00b.rhs.msu.eduœº	#
+!
+csctxns02.campusad.msu.edu=≥	#
+
+xen.cvm.msu.edu=≥	#
+"
+downloadsapgui.ebsp.msu.edu˜	#
+
+bamboo.ebsp.msu.edu˜	#
+
+www.contact.oss.msu.edu˜	#
+#
+www.beta.advancement.msu.edu™	#
+'
+ intranetapps.advancement.msu.eduÄ™	#
+
+fin.ebsp.msu.edu˜	#
+
+sds.rcpd.msu.edu˜	#
+
+citrix.hit.msu.edu&≥	#
+
+rwdt.ebsp.msu.edu˜	#
+%
+vmc-ctx-license.vetmed.msu.edu&≥	#
+
+web.cvm.msu.edu=≥	#
+!
+csctxsf02.campusad.msu.edu&≥	#
+
+www.healthwise.msu.edu˜	#
+
+aid.advancement.msu.edu'™	#
+
+holmes.rhs.msu.eduœº	#
+
+ctlr.msu.edu:¥	#
+
+fisheye.ebsp.msu.edu˜	#
+
+is.rhs.msu.edu)Ω	#
+
+soilweb.spnl.msu.edu?€	#
+
+wireless.msu.edu˜	#
+
+home.rsgis.msu.edu∆ˆ	#
+
+www.etime.msu.edu˜	#
+
+mailprotection.msu.edu˜	#
+!
+csctxns01.campusad.msu.edu=≥	#
+
+citrix.hit.msu.edu=≥	#
+
+books.rcpd.msu.edu˜	#
+
+rsgis.msu.edu∆ˆ	#
+
+bolderit.msu.edu˜	#
+#
+www.coastwatch.rsgis.msu.edu∆ˆ	#
+
+dcpahonline.msu.edu=≥	#
+
+spartanmail.msu.edu˜	#
+
+coastwatch.msu.edu∆ˆ	#
+
+plugin.ebsp.msu.edu˜	#
+%
+vmc-ctx-licens2.vetmed.msu.edu=≥	#
+
+xen.hit.msu.edu&≥	#
+
+www.healtheguide.msu.edu˜	#
+
+www.webenroll.msu.edu˜	#
+
+watson.rhs.msu.eduœº	#
+&
+athultratime.itservices.msu.edu˜	#
+
+www.coastwatch.msu.edu∆ˆ	#
+
+download.ebsp.msu.edu˜	#
+!
+qmsu00a.rhsnet.rhs.msu.eduœº	#
+
+dev.citrix.hit.msu.edu=≥	#
+
+www.ombudsman.msu.edu˜	#
+#
+athmobile.itservices.msu.edu˜	#
+
+reporting.anr.msu.edu˜	#
+
+sirsonline.msu.edu˜	#
+"
+usys-iis.itservices.msu.edu˜	#
+
+etime.msu.edu˜	#
+
+www.fsra.msu.edu˜	#
+
+degnav.msu.edu˜	#
+(
+!ingham-equalization.rsgis.msu.edu∆ˆ	#
+!
+qmsu00b.rhsnet.rhs.msu.eduœº	#
+
+www.degnav.msu.edu˜	#
+
+sis2apps.ais.msu.edu˜	#
+'
+ biopbprd.qual.itservices.msu.edu˜	#
+#
+reporting.itservices.msu.edu˜	#
+
+coastwatch.rsgis.msu.edu∆ˆ	#
+
+fsra.msu.edu˜	#
+
+ooi.ebsp.msu.edu˜	#
+
+
+go.msu.edu˜	#
+
+www.stu-info.msu.edu˜	#
+
+www.maps.rsgis.msu.edu∆ˆ	#
+
+ep.ebsp.msu.edu˜	#
+
+bi.ebsp.msu.edu˜	#
+
+mail.msu.edu˜	#
+
+gradplan.msu.edu˜	#
+ 
+student-elections.msu.edu˜	#
+
+commonunitcode.msu.edu˜	#
+$
+www.student-elections.msu.edu˜	#
+
+myprofile.rcpd.msu.edu˜	#
+
+maps.msu.edu˜	#
+
+ebs.msu.edu˜	#
+
+herd.msu.edu˜	#
+
+hearlab.msu.edu˜	#
+
+nexus.ebsp.msu.edu˜	#
+
+tourismplan.anr.msu.edu˜	#
+"
+apmadmin.itservices.msu.edu ˜	#
++
+$mobile.ultrabadge.itservices.msu.edu!˜	#
+
+spartan365.msu.edu˜	#
+ 
+assets.itservices.msu.edu ˜	#
+"
+www.neuropsychology.msu.edu˜	#
+
+abuse.msu.edu˜	#
+
+apm.itservices.msu.edu ˜	#
+)
+"athletebookloan.itservices.msu.edu ˜	#
+
+bi.rmi.msu.edu˜	#
+
+mm.ebsp.msu.edu˜	#
+
+hcpimmunize.msu.edu˜	#
+
+myid.msu.edu˜	#
+&
+appportfolio.itservices.msu.edu ˜	#
+
+events.msu.edu˜	#
+
+contact.oss.msu.edu˜	#
+
+caps.itservices.msu.edu ˜	#
+
+coursereserve.msu.edu˜	#
+
+www.bolderit.msu.edu˜	#
+
+tbawareness.msu.edu˜	#
+
+carlos.ular.msu.edu˜	#
+
+biopb.itservices.msu.edu˜	#
+
+keepmsuworking.msu.edu˜	#
+
+www.rfid.msu.edu˜	#
+
+riskmaster.rmi.msu.edu˜	#
+
+tech.msu.edu˜	#
+
+api.search.msu.edu˜	#
+
+hcapp.itservices.msu.edu ˜	#
+
+u.search.msu.edu˜	#
+
+www.besocratic.msu.edu˜	#
+%
+productionservices.ais.msu.edu!˜	#
+
+search.msu.edu˜	#
+%
+www.transfercredit.ais.msu.edu!˜	#
+
+cio.msu.edu˜	#
+
+www.cio.msu.edu˜	#
+
+www.webmemo.ais.msu.edu!˜	#
+!
+www.commonunitcode.msu.edu˜	#
+
+www.clifms.msu.edu˜	#
+
+www.sis2apps.ais.msu.edu˜	#
+
+mystuinfo.msu.edu˜	#
+
+inserts.ctlr.msu.edu˜	#
+
+www.stuinfo.msu.edu˜	#
+%
+rptdelivery.itservices.msu.edu ˜	#
+ 
+eem.itservicedesk.msu.edu+˜	#
+
+clifms.ais.msu.edu!˜	#
+
+www.security.ais.msu.edu!˜	#
+
+keywords.msu.edu˜	#
+
+www.carlos.ular.msu.edu˜	#
+
+mba.broad.msu.eduS˜	#
+
+www.herd.msu.edu˜	#
+
+earm.itservices.msu.edu ˜	#
+
+adistran.ais.msu.edu!˜	#
+
+seu.itservices.msu.edu ˜	#
+
+stu-info.msu.edu˜	#
+
+secureit.msu.edu˜	#
+
+stuinfo.msu.edu˜	#
+
+security.ais.msu.edu!˜	#
+(
+!systempassword.itservices.msu.edu ˜	#
+%
+webcluster1.itservices.msu.edu˜	#
+
+alm.itservices.msu.edu#˜	#
+
+msuid.ais.msu.edu!˜	#
+
+www.soct.msu.edu˜	#
+
+internal.broad.msu.eduS˜	#
+
+www.egradfel.msu.edu˜	#
+
+clifms.msu.edu˜	#
+
+docstatus.ais.msu.edu!˜	#
+
+citrix.hit.msu.edu?˜	#
+ 
+uss.itservicedesk.msu.edu"˜	#
+
+ppm.tech.msu.edu2˜	#
+ 
+pam.itservicedesk.msu.edu+˜	#
+!
+executivemba.broad.msu.eduS˜	#
+!
+usysapi.itservices.msu.edu ˜	#
+
+hvwsoaprd1.nam3.msu.edu
+#
+
+itservicedesk.msu.edu+˜	#
+0
+)spartanimpactdashboard.itservices.msu.edu ˜	#
+'
+ gartnerportal.itservices.msu.edu ˜	#
+
+www.elearn.hc.msu.edu?˜	#
+
+wcu.itservices.msu.edu ˜	#
+ 
+eem.itservicedesk.msu.edu"˜	#
+'
+ visualizer.itservicedesk.msu.edu"˜	#
+#
+docstatus.itservices.msu.edu ˜	#
+
+webenroll.msu.edu˜	#
+
+hvwsoaprd2.nam3.msu.edu
+#
+
+marketing.broad.msu.eduS˜	#
+
+fpid.itservices.msu.edu ˜	#
+
+www.msuid.ais.msu.edu!˜	#
+
+demmer.broad.msu.eduS˜	#
+"
+campdata.itservices.msu.edu ˜	#
+
+itservicedesk.msu.edu"˜	#
+
+www.stuinfo.ais.msu.edu!˜	#
+
+elearn.hc.msu.edu?˜	#
+ 
+www.coursereserve.msu.edu˜	#
+(
+!supportauto.itservicedesk.msu.edu"˜	#
+
+controlpanel.ais.msu.edu!˜	#
+
+www.tech.msu.edu˜	#
+
+www.hcpimmunize.msu.edu˜	#
+
+www.msu.eduE˜	#
+!
+vdi-a-cs2.campusad.msu.edu
+#
+"
+vdi-a-idm1.campusad.msu.edu
+#
+(
+!supportauto.itservicedesk.msu.edu+˜	#
+"
+security.itservices.msu.eduH˜	#
+
+www.gradinfo.msu.edu˜	#
+"
+imaccess.itservices.msu.edu ˜	#
+
+uphysapps.msu.edu˜	#
+
+mbacareers.broad.msu.eduS˜	#
+!
+payrollexpense.ais.msu.edu!˜	#
+
+www.oissinfo.ais.msu.edu!˜	#
+
+shcep.broad.msu.eduS˜	#
+
+edp.broad.msu.eduS˜	#
+
+msuhealth.hc.msu.edu?˜	#
+"
+vdi-a-epc2.campusad.msu.edu
+#
+
+zoom.msu.edu˜	#
+
+accounting.broad.msu.eduS˜	#
+
+msuid.itservices.msu.edu!˜	#
+
+jira.itservices.msu.edu ˜	#
+
+fals.itservices.msu.edu ˜	#
+!
+vdi-b-cs1.campusad.msu.edu
+#
+#
+mobile.itservicedesk.msu.edu"˜	#
+)
+"hospitatlitybusiness.broad.msu.eduS˜	#
+)
+"www.productionservices.ais.msu.edu!˜	#
+
+exceed.broad.msu.eduS˜	#
+ 
+www.aiseforms.ais.msu.edu!˜	#
+ 
+webdoc.itservices.msu.edu ˜	#
+
+www.msuhealth.hc.msu.edu?˜	#
+
+tms-sass.ais.msu.edu!˜	#
+
+vdi-epc.campusad.msu.edu
+#
+(
+!studentintltax.itservices.msu.edu ˜	#
+
+acs.itservices.msu.edu ˜	#
+-
+&spartanimpactportal.itservices.msu.edu ˜	#
+
+scholendow2.ais.msu.edu!˜	#
+ 
+www.dataadmin.ais.msu.edu!˜	#
+!
+vdi-a-cs2.campusad.msu.edu#
+
+www.maps.msu.edu˜	#
+
+roomscheduling.msu.edue˜	#
+%
+studentadminportal.chm.msu.edu<˜	#
+
+hvwsoaprd3.nam3.msu.edu
+#
+
+aiseforms.ais.msu.edu!˜	#
+
+www.cabs.msu.eduZ˜	#
+
+hvuagprd1.nam3.msu.edu#
+
+mbp.broad.msu.eduS˜	#
+
+ras.itservices.msu.edu ˜	#
+
+myhealth.msu.edu?˜	#
+
+ie.broad.msu.eduS˜	#
+
+www.broad.msu.eduS˜	#
+"
+vdi-b-uag2.campusad.msu.edu#
+
+hvuagprdi1.nam3.msu.edu#
+!
+vdi-a-cs1.campusad.msu.edu#
+!
+hvepcprd1.campusad.msu.edu
+#
+ 
+vdi-a-cs.campusad.msu.edu#
+!
+webmemo.itservices.msu.edu!˜	#
+"
+vdi-a-idm1.campusad.msu.edu#
+"
+vdi-a-epc1.campusad.msu.edu#
+&
+reporting.itservicedesk.msu.edu"˜	#
+
+mymsuhealth.hc.msu.edu?˜	#
+ 
+www.itservicedesk.msu.edu+˜	#
+!
+vdi-a-uag.campusad.msu.edu
+#
+%
+webcluster3.itservices.msu.edu!˜	#
+"
+vdi-a-uag1.campusad.msu.edu
+#
+
+hvuagprd1.nam3.msu.edu#
+!
+studentintltax.ais.msu.edu!˜	#
+
+clode.broad.msu.eduS˜	#
+%
+aissecuritycontact.ais.msu.edu!˜	#
+
+hvwsoaprd3.nam3.msu.edu#
+
+cabs.msu.eduZ˜	#
+
+axia.broad.msu.eduS˜	#
+!
+vdi-a-uag.campusad.msu.edu#
+
+ultrabadge.ais.msu.edu!˜	#
+!
+paymentsupport.ais.msu.edu!˜	#
+
+sas2.ais.msu.edu!˜	#
+!
+vdi-a-uag.campusad.msu.edu#
+!
+vdi-a-cs1.campusad.msu.edu#
+!
+hvepcprd2.campusad.msu.edu#
+%
+plant-transformation.glbrc.orgÌ#
+
+full.vpn.msu.edu&˙	#
+
+stuinfo.ais.msu.edu!˜	#
+
+hvuagprd1.nam3.msu.edu
+#
+
+mispartanimpact.msu.edut˜	#
+
+finance.broad.msu.eduS˜	#
+"
+vdi-a-idm2.campusad.msu.edu
+#
+"
+vdi-a-epc2.campusad.msu.edu#
+!
+vdi-b-cs1.campusad.msu.edu#
+"
+vdi-a-idm3.campusad.msu.edu#
+ 
+uptime.itservices.msu.edu ˜	#
+
+baf.glbrc.msu.eduÌ#
+"
+genomics-sync.glbrc.msu.eduÌ#
+"
+vdi-a-epc1.campusad.msu.edu
+#
+"
+vdi-a-uag2.campusad.msu.edu#
+!
+hvepcprd1.campusad.msu.edu#
+
+msmc-sync.glbrc.msu.eduÌ#
+"
+vdi-a-idm3.campusad.msu.edu#
+
+hvwsoaprd2.nam3.msu.edu#
+"
+vdi-a-idm1.campusad.msu.edu#
+
+	cmich.edu
+@!#
+
+	cmich.edu@!#
+
+ts.glbrc.msu.edu"Ì#
+!
+vdi-a-cs1.campusad.msu.edu#
+
+hvuagprdi2.nam3.msu.edu
+#
+
+hvuagprd2.nam3.msu.edu
+#
+
+hvuagprdi1.nam3.msu.edu#
+
+hvwsoaprd2.nam3.msu.edu#
+
+msu.eduE˜	#
+#
+readonlymsuhealth.hc.msu.edu?˜	#
+
+www.addrarch.ais.msu.edu!˜	#
+
+erequest.asmsu.msu.edup˜	#
+!
+hvepcprd2.campusad.msu.edu#
+
+weekendmba.broad.msu.eduS˜	#
+
+	cmich.edu'@!#
+
+	cmich.eduP@!#
+
+	cmich.eduO@!#
+"
+vdi-a-idm2.campusad.msu.edu#
+
+hvwsoaprd3.nam3.msu.edu#
+
+www.mss.msu.eduU˜	#
+!
+vdi-a-cs1.campusad.msu.edu
+#
+"
+vdi-b-uag1.campusad.msu.edu#
+
+	cmich.eduF@!#
+
+vdi-uag.campusad.msu.edu#
+
+brand.msu.edu]˜	#
+
+	cmich.eduN@!#
+
+vdi.msu.edu
+#
+'
+ makebusinesshappen.broad.msu.eduS˜	#
+
+	cmich.eduM@!#
+
+hvuagprdi1.nam3.msu.edu#
+
+lear.broad.msu.eduS˜	#
+"
+vdi-a-idm1.campusad.msu.edu#
+
+railway.broad.msu.eduS˜	#
+&
+midlandvaluechain.broad.msu.eduS˜	#
+!
+hvepcprd2.campusad.msu.edu
+#
+
+	cmich.eduE@!#
+"
+vdi-b-uag1.campusad.msu.edu#
+
+hvuagprd2.nam3.msu.edu#
+
+vdi-uag.campusad.msu.edu#
+"
+vdi-a-idm2.campusad.msu.edu#
+"
+vdi-a-idm2.campusad.msu.edu#
+"
+vdi-b-uag2.campusad.msu.edu#
+
+hvuagprd2.nam3.msu.edu#
+ 
+supplychain.broad.msu.eduS˜	#
+!
+hvepcprd2.campusad.msu.edu#
+ 
+vdi-a-cs.campusad.msu.edu#
+"
+vdi-a-epc1.campusad.msu.edu#
+!
+vdi-b-cs2.campusad.msu.edu#
+"
+vdi-b-uag1.campusad.msu.edu
+#
+
+	cmich.edu,@!#
+"
+vdi-b-uag1.campusad.msu.edu#
+"
+vdi-a-uag1.campusad.msu.edu#
+
+	cmich.eduê@!#
+
+vdi-uag.campusad.msu.edu
+#
+
+	cmich.edu@!#
+
+	cmich.eduî@!#
+
+	cmich.edu*@!#
+ 
+vdi-a-cs.campusad.msu.edu#
+
+vdi.msu.edu#
+
+	cmich.edu‰@!#
+"
+vdi-a-uag1.campusad.msu.edu#
+"
+vdi-a-uag2.campusad.msu.edu#
+!
+hvepcprd2.campusad.msu.edu#
+
+vdi-epc.campusad.msu.edu#
+"
+vdi-a-uag1.campusad.msu.edu#
+!
+vdi-a-cs2.campusad.msu.edu#
+
+vdi-epc.campusad.msu.edu#
+
+vdi.msu.edu#
+ 
+vdi-a-cs.campusad.msu.edu#
+"
+vdi-a-uag2.campusad.msu.edu
+#
+
+	cmich.edu·@!#
+"
+vdi-a-uag1.campusad.msu.edu#
+
+hvuagprd2.nam3.msu.edu#
+
+hvwsoaprd1.nam3.msu.edu#
+"
+vdi-b-uag1.campusad.msu.edu#
+"
+vdi-a-idm3.campusad.msu.edu#
+
+	cmich.edu}@!#
+
+hvwsoaprd1.nam3.msu.edu#
+"
+vdi-a-epc2.campusad.msu.edu#
+"
+vdi-a-idm1.campusad.msu.edu#
+"
+vdi-a-epc2.campusad.msu.edu#
+
+	cmich.eduT@!#
+
+vdi-epc.campusad.msu.edu#
+"
+vdi-a-uag2.campusad.msu.edu#
+
+hvuagprdi2.nam3.msu.edu#
+
+hvwsoaprd2.nam3.msu.edu#
+
+	cmich.eduQ@!#
+
+	cmich.edut@!#
+
+hvwsoaprd1.nam3.msu.edu#
+"
+vdi-a-epc2.campusad.msu.edu#
+
+hfcc.netOÀ2
+
+hfcc.eduPÀ2
+!
+hvepcprd1.campusad.msu.edu#
+ 
+vdi-a-cs.campusad.msu.edu
+#
+
+	cmich.edu)@!#
+
+hvwsoaprd3.nam3.msu.edu#
+
+vdi.msu.edu#
+
+hvuagprdi2.nam3.msu.edu#
+
+hvuagprd1.nam3.msu.edu#
+
+	cmich.edu:@!#
+
+hfcc.edu^À2
+
+hfcc.eduÿÀ2
+"
+vdi-b-uag2.campusad.msu.edu#
+
+hvuagprdi2.nam3.msu.edu#
+!
+vdi-b-cs2.campusad.msu.edu#
+"
+vdi-a-idm2.campusad.msu.edu#
+
+vdi-uag.campusad.msu.edu#
+
+	cmich.eduC@!#
+
+test-mtdvm.oaklandcc.eduÓÏsJ
+
+hfcc.eduQÀ2
+
+	cmich.eduç@!#
+"
+vdi-a-epc1.campusad.msu.edu#
+!
+vdi-b-cs2.campusad.msu.edu
+#
+
+hvuagprdi1.nam3.msu.edu#
+
+	cmich.eduî@!#
+
+	cmich.edu˛C!#
+
+turn.oaklandcc.edu°ÌsJ
+
+hvuagprd1.nam3.msu.edu#
+!
+vdi-b-cs2.campusad.msu.edu#
+
+mobility.oaklandcc.edu¢ÌsJ
+
+hfcc.edu$À2
+
+	cmich.edu=@!#
+"
+vdi-a-epc1.campusad.msu.edu#
+
+mitel.oaklandcc.edu¢ÌsJ
+
+hvwsoaprd3.nam3.msu.edu#
+
+mt-dvm.oaklandcc.edu¢ÌsJ
+
+hfcc.net\À2
+
+hvwsoaprd1.nam3.msu.edu#
+!
+vdi-a-cs2.campusad.msu.edu#
+
+acd.oaklandcc.edu¢ÏsJ
+
+	cmich.eduV@!#
+
+	cmich.eduD!#
+"
+vdi-a-uag2.campusad.msu.edu#
+
+bnadm01.davenport.eduI∆ B
+
+test-mtecc.oaklandcc.eduÓÏsJ
+
+testegw.oaklandcc.eduÓÌsJ
+
+	cmich.edu+@!#
+"
+view01.cyberrange.merit.edu·>#
+
+hfcc.edugÀ2
+
+mt-ecc.oaklandcc.eduÌÌsJ
+
+	cmich.edu÷@!#
+
+hvwsoaprd2.nam3.msu.edu#
+ 
+degreeplan2.davenport.edu>∆ B
+
+davenport.edu4∆ B
+
+conference.oaklandcc.edu°ÌsJ
+
+	cmich.eduB@!#
+
+davenport.edu#∆ B
+
+davenport.eduk¿ B
+
+	cmich.edu`@!#
+
+davenport.eduj¿ B
+
+mt-ecc.oaklandcc.edu¢ÏsJ
+
+hvuagprd2.nam3.msu.edu#
+
+infomart.oaklandcc.edu~ÏsJ
+
+remote.oaklandcc.eduÇÏsJ
+
+	cmich.eduR@!#
+
+vdi-uag.campusad.msu.edu#
+
+	cmich.eduë@!#
+ 
+mt-director.oaklandcc.edu¢ÌsJ
+
+mobility.oaklandcc.edu¢ÏsJ
+!
+vdi-a-uag.campusad.msu.edu#
+"
+view01.cyberrange.merit.edu·>#
+
+bnssb04.davenport.eduM∆ B
+
+oaklandcc.edu¡ÏsJ
+
+	cmich.eduÕ@!#
+
+	cmich.edu_@!#
+
+conference.oaklandcc.eduÌÌsJ
+
+hfcc.eduGÀ2
+
+testacd.oaklandcc.eduÌsJ
+
+	cmich.eduND!#
+
+turn.oaklandcc.edu¢ÏsJ
+
+shoretel.oaklandcc.eduÔÌsJ
+
+	cmich.edu@@!#
+
+	cmich.eduOD!#
+
+www.oaklandcc.edu¡ÏsJ
+
+	cmich.eduS@!#
+!
+netlabve.cot.davenport.eduÀ› B
+
+vdi.oaklandcc.edu¨ÌsJ
+
+davenport.edu^∆ B
+
+hfcc.edu3À2
+ 
+mt-director.oaklandcc.eduÌÌsJ
+
+	cmich.edun@!#
+!
+vdi-b-cs1.campusad.msu.edu#
+ 
+mt-director.oaklandcc.edu¢ÏsJ
+
+cwpaygate.oaklandcc.eduÌsJ
+
+mitel.oaklandcc.edu°ÌsJ
+
+davenport.edu$∆ B
+
+bnssb02.davenport.eduK∆ B
+
+mt-ecc.oaklandcc.edu¢ÌsJ
+
+testturn.oaklandcc.eduÓÏsJ
+
+itvdi.oaklandcc.edu´ÌsJ
+
+reporting.davenport.eduQ∆ B
+
+mitel.oaklandcc.edu¢ÏsJ
+$
+test-mtdirector.oaklandcc.eduÌsJ
+
+bnssb03.davenport.eduL∆ B
+
+testrast.oaklandcc.eduÌsJ
+
+	cmich.edu
+D!#
+
+shoretel.oaklandcc.edu°ÌsJ
+
+test-mtdvm.oaklandcc.eduÌsJ
+
+egw.oaklandcc.edu¢ÏsJ
+
+rast.oaklandcc.edu°ÌsJ
+
+infomart.oaklandcc.edu~ÌsJ
+
+	cmich.edu)D!#
+
+testmitel.oaklandcc.eduÓÏsJ
+
+	cmich.edu§@!#
+
+turn.oaklandcc.eduÌÌsJ
+
+mt-dvm.oaklandcc.edu°ÌsJ
+
+rp.oaklandcc.edu°ÌsJ
+
+conference.oaklandcc.edu¢ÌsJ
+
+turn.oaklandcc.edu¢ÌsJ
+
+	cmich.eduî@!#
+
+conference.oaklandcc.edu¢ÏsJ
+
+testegw.oaklandcc.eduÙÌsJ
+
+test-mtecc.oaklandcc.eduÌsJ
+
+mobility.oaklandcc.edu°ÌsJ
+
+mt-dvm.oaklandcc.edu¢ÏsJ
+ 
+mt-director.oaklandcc.edu°ÌsJ
+
+egw.oaklandcc.edu¢ÌsJ
+
+turn.oaklandcc.eduÔÌsJ
+
+mobility.oaklandcc.eduÌÌsJ
+
+testmitel.oaklandcc.eduÌsJ
+
+testegw.oaklandcc.eduÓÏsJ
+
+vdi.oaklandcc.edu¨ÌsJ
+
+testrp.oaklandcc.eduÙÌsJ
+
+mt-dvm2.oaklandcc.edu¢ÌsJ
+
+testegw.oaklandcc.eduÌsJ
+!
+testmobility.oaklandcc.eduÙÌsJ
+
+egw.oaklandcc.edu°ÌsJ
+
+itvdi.oaklandcc.edu´ÌsJ
+
+	cmich.eduﬁ@!#
+!
+testmobility.oaklandcc.eduÓÏsJ
+
+mlbpa.davenport.edu`∆ B
+
+acd.oaklandcc.edu°ÌsJ
+
+testturn.oaklandcc.eduÌsJ
+
+testturn.oaklandcc.eduÓÌsJ
+
+davenport.edua∆ B
+
+testvsa.oaklandcc.eduÌsJ
+
+rp.oaklandcc.edu¢ÌsJ
+
+testrp.oaklandcc.eduÌsJ
+
+testrp.oaklandcc.eduÓÌsJ
+
+shoretel.oaklandcc.eduÌÌsJ
+
+mt-dvm2.oaklandcc.eduÌÌsJ
+
+test-mtecc.oaklandcc.eduÓÌsJ
+
+test-mtdvm.oaklandcc.eduÙÌsJ
+
+testacd.oaklandcc.eduÙÌsJ
+
+testrp.oaklandcc.eduÓÏsJ
+
+rast.oaklandcc.edu¢ÏsJ
+
+mitel.oaklandcc.eduÌÌsJ
+
+testturn.oaklandcc.eduÙÌsJ
+
+ssomanager.davenport.eduR∆ B
+
+remote.oaklandcc.eduÇÌsJ
+
+myocc.oaklandcc.eduâÌsJ
+
+acd.oaklandcc.edu¢ÌsJ
+
+testvsa.oaklandcc.eduÓÏsJ
+
+mitel.oaklandcc.eduÔÌsJ
+
+bnprodssb3.davenport.edu*∆ B
+
+testrast.oaklandcc.eduÙÌsJ
+
+testrast.oaklandcc.eduÓÏsJ
+
+mt-dvm2.oaklandcc.eduÔÌsJ
+!
+testmobility.oaklandcc.eduÌsJ
+
+testacd.oaklandcc.eduÓÏsJ
+
+psprodes.grcc.eduTòtJ
+
+testrast.oaklandcc.eduÓÌsJ
+
+ibprod.grcc.eduTòtJ
+
+acd.oaklandcc.eduÔÌsJ
+
+rast.oaklandcc.edu¢ÌsJ
+
+multiplan.oaklandcc.eduÌsJ
+
+psprodps1.grcc.eduTòtJ
+
+guac2.grcc.eduòtJ
+
+psprodw3.grcc.eduTòtJ
+
+courses.grcc.eduUòtJ
+
+	cmich.eduã@!#
+
+mt-ecc.oaklandcc.edu°ÌsJ
+
+fsprod.grcc.eduTòtJ
+
+hrprod.grcc.eduUòtJ
+
+fsprod.grcc.eduUòtJ
+
+testacd.oaklandcc.eduÓÌsJ
+$
+test-mtdirector.oaklandcc.eduÓÌsJ
+
+mt-dvm2.oaklandcc.edu°ÌsJ
+
+psprodae1.grcc.eduTòtJ
+
+psprodw4-2021.grcc.eduTòtJ
+
+courses.grcc.eduTòtJ
+
+rp.oaklandcc.eduÔÌsJ
+
+apps.oaklandcc.edu∞ÌsJ
+
+psproda4-2021.grcc.eduTòtJ
+
+imaging.oaklandcc.eduñÌsJ
+
+psproda1.grcc.eduUòtJ
+
+rast.oaklandcc.eduÔÌsJ
+
+psprodw1.grcc.eduTòtJ
+
+psprodes3.grcc.eduTòtJ
+
+csprod.grcc.eduTòtJ
+
+psprodw1.grcc.eduUòtJ
+
+psprodps2.grcc.eduTòtJ
+
+csprod.grcc.eduUòtJ
+
+hrprod.grcc.edunòtJ
+
+psprodw3.grcc.edunòtJ
+
+psprodps1-2021.grcc.eduTòtJ
+
+rast.oaklandcc.eduÌÌsJ
+
+psprodw2.grcc.eduTòtJ
+
+psprodes1-2021.grcc.eduTòtJ
+
+courses.grcc.edunòtJ
+
+psprodes2-2021.grcc.eduUòtJ
+
+ibprod.grcc.eduUòtJ
+
+psprodes2.grcc.eduTòtJ
+
+psprodes1.grcc.eduUòtJ
+
+psproda1.grcc.eduTòtJ
+
+ibcsprod.grcc.eduTòtJ
+
+apps.oaklandcc.edu∞ÌsJ
+
+psprodes2.grcc.eduUòtJ
+ 
+mt-director.oaklandcc.eduÔÌsJ
+
+psproda4.grcc.eduTòtJ
+
+psprodes3.grcc.edunòtJ
+
+psprodps2-2021.grcc.eduTòtJ
+
+psprodes3-2021.grcc.eduUòtJ
+
+ibepprod.grcc.eduUòtJ
+
+psproda2.grcc.eduUòtJ
+
+ibepprod.grcc.eduTòtJ
+
+conference.oaklandcc.eduÔÌsJ
+
+testvsa.oaklandcc.eduÓÌsJ
+
+psprodw4.grcc.eduTòtJ
+
+oc.grcc.eduoòtJ
+
+psprodes1.grcc.eduTòtJ
+
+hrprod.grcc.eduTòtJ
+
+psprodw3.grcc.eduoòtJ
+
+psproda3-2021.grcc.eduTòtJ
+
+egw.oaklandcc.eduÌÌsJ
+
+psprodes1-2021.grcc.eduoòtJ
+
+csprod.grcc.eduúòtJ
+
+ibhrprod.grcc.edunòtJ
+
+psprodw4-2021.grcc.eduoòtJ
+
+vpn.oaklandcc.edueÌsJ
+
+ibcsprod.grcc.eduoòtJ
+
+oc.grcc.eduTòtJ
+
+psprodw2-2021.grcc.eduTòtJ
+
+psprodes1-2021.grcc.eduUòtJ
+
+ibfsprod.grcc.eduTòtJ
+
+test-mtecc.oaklandcc.eduÙÌsJ
+
+psproda4.grcc.eduUòtJ
+
+ibcsprod.grcc.eduUòtJ
+
+psproda1-2021.grcc.edunòtJ
+
+psproda4-2021.grcc.edunòtJ
+
+courses.grcc.eduúòtJ
+
+epprod.grcc.eduúòtJ
+
+psprodw1-2021.grcc.eduTòtJ
+
+psprodes.grcc.edunòtJ
+
+psprodae1-2021.grcc.eduUòtJ
+
+rp.oaklandcc.eduÌÌsJ
+
+ibepprod.grcc.eduoòtJ
+
+ibhrprod.grcc.eduTòtJ
+
+psprodw4-2021.grcc.eduUòtJ
+
+guac.grcc.eduòtJ
+
+psproda2.grcc.edunòtJ
+
+psproda1-2021.grcc.eduUòtJ
+
+psprodps1-2021.grcc.edunòtJ
+
+mt-ecc.oaklandcc.eduÔÌsJ
+
+testmitel.oaklandcc.eduÙÌsJ
+
+psprodw2-2021.grcc.eduUòtJ
+$
+test-mtdirector.oaklandcc.eduÙÌsJ
+
+classclimate.grcc.eduãòtJ
+
+psprodes3.grcc.eduoòtJ
+
+psproda3.grcc.eduoòtJ
+
+psprodes2-2021.grcc.eduTòtJ
+
+psprodw4.grcc.eduUòtJ
+
+csprod.grcc.edunòtJ
+
+psproda1-2021.grcc.eduTòtJ
+
+psproda2-2021.grcc.eduUòtJ
+
+egw.oaklandcc.eduÔÌsJ
+
+psprodes.grcc.eduUòtJ
+
+testvsa.oaklandcc.eduÙÌsJ
+
+psproda2.grcc.eduTòtJ
+
+psprodw4.grcc.eduoòtJ
+
+psproda3.grcc.eduUòtJ
+
+epprod.grcc.eduTòtJ
+
+psprodps2.grcc.edunòtJ
+
+epprod.grcc.eduUòtJ
+
+psprodps1.grcc.eduUòtJ
+
+ibfsprod.grcc.eduúòtJ
+
+psprodw2-2021.grcc.edunòtJ
+
+ccsurveys.grcc.eduãòtJ
+
+psproda4.grcc.edunòtJ
+
+psproda3.grcc.edunòtJ
+
+psprodw1-2021.grcc.edunòtJ
+
+psprodes2-2021.grcc.edunòtJ
+
+fsprod.grcc.eduúòtJ
+
+ibfsprod.grcc.eduUòtJ
+
+psprodes1.grcc.eduoòtJ
+
+psprodw3-2021.grcc.eduTòtJ
+
+psprodps1.grcc.edunòtJ
+
+pskbprod.grcc.eduTòtJ
+
+psproda2-2021.grcc.eduTòtJ
+
+ibepprod.grcc.edunòtJ
+
+psprodw2.grcc.eduUòtJ
+
+pskbprod.grcc.edunòtJ
+
+fsprod.grcc.edunòtJ
+
+ibcsprod.grcc.eduúòtJ
+
+oc.grcc.eduUòtJ
+
+psproda3.grcc.eduúòtJ
+
+psprodae1-2021.grcc.eduTòtJ
+
+psproda3-2021.grcc.eduUòtJ
+
+psprodes1-2021.grcc.edunòtJ
+
+psprodps2-2021.grcc.edunòtJ
+
+psprodes2.grcc.eduoòtJ
+
+psproda2-2021.grcc.eduoòtJ
+
+psprodae1.grcc.eduúòtJ
+
+psprodes1-2021.grcc.eduúòtJ
+
+ibprod.grcc.edunòtJ
+
+psproda3-2021.grcc.eduúòtJ
+
+psprodes2.grcc.edunòtJ
+
+ibcsprod.grcc.edunòtJ
+
+psprodw2.grcc.edunòtJ
+
+psprodae1-2021.grcc.edunòtJ
+
+psproda4-2021.grcc.eduUòtJ
+
+psprodps1.grcc.eduoòtJ
+
+psproda3.grcc.eduTòtJ
+
+psproda4-2021.grcc.eduúòtJ
+
+psprodps1-2021.grcc.eduúòtJ
+
+jobs.grcc.eduoòtJ
+
+ibfsprod.grcc.edunòtJ
+
+psprodps2.grcc.eduUòtJ
+
+oc.grcc.edunòtJ
+
+psprodae1-2021.grcc.eduúòtJ
+
+psproda3-2021.grcc.edunòtJ
+
+pskbprod.grcc.eduUòtJ
+
+psproda2-2021.grcc.eduúòtJ
+
+psprodae1.grcc.eduoòtJ
+
+psprodw1.grcc.edunòtJ
+
+psprodps1-2021.grcc.eduoòtJ
+
+psproda1.grcc.edunòtJ
+
+hrprod.grcc.eduúòtJ
+
+psprodw1-2021.grcc.eduUòtJ
+
+ibprod.grcc.eduoòtJ
+
+ibs-lb.colorado.eduûCäÄ
+
+psprodw2-2021.grcc.eduoòtJ
+
+psprodw2.grcc.eduúòtJ
+
+jobs.grcc.eduúòtJ
+
+psproda3-2021.grcc.eduoòtJ
+"
+buffportal.gtm.colorado.edu^CäÄ
+*
+#external-identikey.gtm.colorado.edu[CäÄ
+
+epprod.grcc.edunòtJ
+
+psprodw3-2021.grcc.eduUòtJ
+
+psproda1-2021.grcc.eduúòtJ
+
+jobs.grcc.eduUòtJ
+
+psprodes1.grcc.edunòtJ
+
+ibprod.grcc.eduúòtJ
+
+psprodps2-2021.grcc.eduoòtJ
+
+oc.grcc.eduúòtJ
+
+psprodes3-2021.grcc.edunòtJ
+
+psprodes.grcc.eduoòtJ
+
+psprodps1-2021.grcc.eduUòtJ
+
+psprodae1.grcc.edunòtJ
+
+psprodw4-2021.grcc.edunòtJ
+
+7pts.colorado.edu#\äÄ
+
+arroyo.colorado.eduBFäÄ
+
+psprodes2-2021.grcc.eduúòtJ
+
+psprodps2.grcc.eduúòtJ
+
+psprodw3-2021.grcc.eduúòtJ
+
+psproda1.grcc.eduoòtJ
+
+psprodw3.grcc.eduúòtJ
+
+ibepprod.grcc.eduúòtJ
+
+psprodw1-2021.grcc.eduoòtJ
+
+psproda4.grcc.eduúòtJ
+
+psprodes3-2021.grcc.eduoòtJ
+"
+identikey-comp.colorado.edu[CäÄ
+
+psproda2.grcc.eduúòtJ
+
+epprod.grcc.eduoòtJ
+
+pskbprod.grcc.eduoòtJ
+
+dosequis.colorado.eduFHäÄ
+"
+biof-imagewiki.colorado.edu/]äÄ
+
+www.theoryon.orgCäÄ
+
+atoc-test.colorado.eduIäÄ
+
+theoryon.orgCäÄ
+
+psproda1-2021.grcc.eduoòtJ
+
+psprodps2-2021.grcc.eduúòtJ
+
+ofa.colorado.eduDäÄ
+
+atoc.colorado.eduIäÄ
+
+psprodes3.grcc.eduUòtJ
+
+psprodw4-2021.grcc.eduúòtJ
+
+identikey.colorado.edu[CäÄ
+"
+identikey-spsc.colorado.edu[CäÄ
+
+ibhrprod.grcc.eduúòtJ
+
+courses.grcc.eduoòtJ
+
+psprodw3-2021.grcc.eduoòtJ
+
+psproda2.grcc.eduoòtJ
+
+psprodes1.grcc.eduúòtJ
+
+regnet.colorado.eduDäÄ
+
+tungsten.grcc.eduùòtJ
+
+monitor.grcc.eduôtJ
+
+prtg.grcc.eduôtJ
+
+ibhrprod.grcc.eduoòtJ
+
+pshop.grcc.edu®òtJ
+
+camra.colorado.edu8IäÄ
+
+ibs-ibs.colorado.edu®CäÄ
+
+jobs.grcc.edunòtJ
+
+oit-web01.colorado.edu\äÄ
+
+psproda4-2021.grcc.eduoòtJ
+
+cln.colorado.edu\äÄ
+
+hazards.colorado.eduèCäÄ
+
+hdssecrets.colorado.eduWäÄ
+#
+buffportal-comp.colorado.edu^CäÄ
+
+psprodw2-2021.grcc.eduúòtJ
+!
+leeds-faculty.colorado.eduCäÄ
+
+spot.colorado.edu\äÄ
+
+emsrmview.colorado.edu#\äÄ
+
+hdsapps.colorado.eduaäÄ
+ 
+skillscenter.colorado.eduFHäÄ
+
+hdsf5.colorado.eduäÄ
+
+psprodps1.grcc.eduúòtJ
+
+psprodes2.grcc.eduúòtJ
+
+psprodw1.grcc.eduúòtJ
+
+euclid.colorado.edu9IäÄ
+
+cspv.colorado.edu¢CäÄ
+
+printshop.grcc.edu®òtJ
+
+ofainternal.colorado.eduDäÄ
+
+emscampusvc.colorado.edu#\äÄ
+
+beesneeds.colorado.edu\äÄ
+
+psprodes3.grcc.eduúòtJ
+
+psprodes2-2021.grcc.eduoòtJ
+-
+&learningassistantalliance.colorado.edu\äÄ
+
+bs.colorado.eduûCäÄ
+
+pskbprod.grcc.eduúòtJ
+
+psprodes.grcc.eduúòtJ
+
+qijc.colorado.edu$DäÄ
+
+ceps.colorado.eduÀäÄ
+
+psprodw1-2021.grcc.eduúòtJ
+
+storm-test.colorado.eduIäÄ
+
+emsweb.colorado.edu#\äÄ
+
+garcealab.colorado.eduFHäÄ
+
+eprint.grcc.edu®òtJ
+
+sareports.colorado.eduäÄ
+
+qijc-test.colorado.edu$DäÄ
+
+ibs.colorado.eduûCäÄ
+
+ibs-legacy.colorado.eduÜCäÄ
+
+bioliteracy.colorado.eduFHäÄ
+
+mail.cubookstore.comçeäÄ
+
+math.colorado.edu9IäÄ
+!
+cucontent-new.colorado.educÅäÄ
+
+niwotlter.colorado.edu2WäÄ
+
+lmsmanager.colorado.eduÏäÄ
+)
+"demo.learningassistantalliance.org\äÄ
+
+musm-apps-2.colorado.edu	\äÄ
+
+hoengerlab.colorado.eduFHäÄ
+
+nanoserver2.colorado.edu\äÄ
+
+casa-test.colorado.eduëIäÄ
+%
+converge-training.colorado.eduéCäÄ
+
+psprodes3-2021.grcc.eduúòtJ
+
+ceae-server.colorado.eduIäÄ
+
+bio3d.colorado.eduXHäÄ
+
+fiji-dtn.colorado.edu2]äÄ
+
+ceps.spacescience.orgÀäÄ
+
+lpcams.cubookstore.comõeäÄ
+
+mcdbiology.colorado.eduFHäÄ
+
+studentjobs.colorado.eduDäÄ
+
+mcdb70.colorado.eduFHäÄ
+
+registrar.colorado.eduDäÄ
+!
+linux-train-4.colorado.eduh\äÄ
+
+ceasjira.colorado.eduQaäÄ
+
+dna.colorado.eduL]äÄ
+
+qfadd.colorado.eduYäÄ
+!
+leeds-faculty.colorado.eduCäÄ
+
+stix.colorado.edu!YäÄ
+
+buffportal.colorado.eduÙäÄ
+
+hdsprojects.colorado.eduºäÄ
+%
+beesneeds-upgrade.colorado.edu\äÄ
+
+chuonglab.colorado.educ]äÄ
+
+www.lasp.linkÉäÄ
+
+urquell.colorado.eduÂäÄ
+$
+learningassistantalliance.org\äÄ
+%
+behavioralscience.colorado.eduûCäÄ
+#
+buffportal-spsc.colorado.edu^CäÄ
+
+webtmatest.colorado.edueäÄ
+
+elements.colorado.eduväÄ
+
+tma.colorado.edußäÄ
+
+amath.colorado.edu\äÄ
+
+umc-ems01.colorado.edu#\äÄ
+)
+"bocolatinohistory-dev.colorado.edu\äÄ
+
+themis.colorado.edu»äÄ
+.
+'fossilvertebratesandtraces.colorado.edu\äÄ
+#
+advancedimaging.colorado.edu"]äÄ
+
+psproda1.grcc.eduúòtJ
+
+ccar.colorado.edu	aäÄ
+
+ems.colorado.edu#\äÄ
+
+converge.colorado.edu≈CäÄ
+
+lynda.colorado.edu÷ÄäÄ
+
+colorado.edubÅäÄ
+
+cucontent.colorado.edu \äÄ
+
+ibsweb.colorado.eduâCäÄ
+
+linux.colorado.eduò]äÄ
+
+bro.colorado.eduQ]äÄ
+
+cupc.colorado.edu£CäÄ
+'
+ nano-optics-upgrade.colorado.edu\äÄ
+
+mail.cubookstore.comçeäÄ
+!
+ucbsccm-sup02.colorado.eduÿäÄ
+
+yilab.colorado.eduFHäÄ
+
+itll.colorado.eduFaäÄ
+
+extranet.nsidc.org+áäÄ
+ 
+emswebclient.colorado.edu#\äÄ
+(
+!www.learningassistantalliance.org\äÄ
+!
+klymkowskylab.colorado.eduFHäÄ
+
+bechtel.colorado.eduIäÄ
+
+casa.colorado.eduëIäÄ
+
+bayes.colorado.eduñ]äÄ
+
+tfea.colorado.edu9YäÄ
+
+libraries.colorado.edu\äÄ
+'
+ vivo-cub-setup-test.colorado.eduËäÄ
+!
+biof-trackhub.colorado.eduYäÄ
+
+phet-dev.colorado.eduÅäÄ
+
+storm.colorado.eduIäÄ
+%
+virtuallaboratory.colorado.eduFHäÄ
+
+slhc-web.colorado.edu\äÄ
+
+bit.colorado.eduZ]äÄ
+-
+&learningassistantalliance.colorado.edu\äÄ
+"
+lawcollections.colorado.eduìpäÄ
+
+emm-msf-vpn.colorado.edu3ÉäÄ
+ 
+law-termkwip.colorado.edu€äÄ
+
+palmerlab.colorado.edus]äÄ
+"
+buffportal.gtm.colorado.eduJÄäÄ
+
+voicethread.colorado.edu2ÄäÄ
+ 
+docusigntest.colorado.eduÅäÄ
+
+qualtrics.colorado.edu5ÄäÄ
+
+nascent.colorado.edup]äÄ
+
+cods.colorado.eduaäÄ
+
+colorado.edu4ÅäÄ
+
+phet-api.colorado.eduNÅäÄ
+
+nano-optics.colorado.edu\äÄ
+"
+vivo-cub-setup.colorado.eduËäÄ
+
+rintintin.colorado.edu\äÄ
+
+remote.colorado.eduépäÄ
+
+sparky.colorado.edu¨]äÄ
+
+vaxfirst.colorado.edu
+]äÄ
+&
+external-identikey.colorado.eduyÅäÄ
+
+extranet.nsidc.orgiáäÄ
+
+inside.nsidc.org+áäÄ
+
+bst-db.colorado.eduå\äÄ
+
+bst-serve.colorado.eduà\äÄ
+
+jilafile.colorado.edukäÄ
+#
+buffportal-comp.colorado.eduJÄäÄ
+
+ems1.colorado.edu#\äÄ
+&
+studyabroad-legacy.colorado.edud\äÄ
+
+gtpfeedback.colorado.eduÁäÄ
+ 
+kibana.refraction.networkæaäÄ
+"
+cucontent-comp.colorado.edu^ÅäÄ
+
+buffportal.colorado.eduJÄäÄ
+
+phoebe.colorado.eduä\äÄ
+
+identikey.colorado.eduyÅäÄ
++
+$studyabroad-legacy-test.colorado.edud\äÄ
+#
+buffportal-spsc.colorado.eduJÄäÄ
+
+extranet.nsidc.org+áäÄ
+
+biodatasci.colorado.edu$]äÄ
+!
+mygroups-test.colorado.eduèÅäÄ
+
+playposit.colorado.edu9ÄäÄ
+!
+ucbsccm-sup02.colorado.eduÿäÄ
+
+lasp.colorado.eduÉäÄ
+
+staging.nsidc.org+áäÄ
+
+www-ucb.colorado.edu£ÅäÄ
+
+mail.cubookstore.comçeäÄ
+
+lawdigital.colorado.eduìpäÄ
+
+	nsidc.orgiáäÄ
+"
+identikey-spsc.colorado.eduyÅäÄ
+
+	nsidc.org+áäÄ
+ 
+cube-webprod.colorado.eduväÄ
+
+fedauth.colorado.edu∆ÅäÄ
+
+www.colorado.edubÅäÄ
+
+staging.inside.nsidc.orgiáäÄ
+
+pacesproject.orgYàäÄ
+
+k2.colorado.eduiáäÄ
+
+ciresgroups.colorado.eduøàäÄ
+
+qa.nsidc.org+áäÄ
+
+qa.nsidc.org+áäÄ
+
+lasp-auth.colorado.edu"ÉäÄ
+
+cuadmin.colorado.eduCÄäÄ
+!
+tvguide-aniso.colorado.edu≤àäÄ
+
+ccog.colorado.edu«àäÄ
+
+ciscopca.colorado.eduCÄäÄ
+
+remote.colorado.eduépäÄ
+
+www.egy.orgÉäÄ
+"
+ciresmentoring.colorado.edu±àäÄ
+
+inside.nsidc.org+áäÄ
+
+mail.cubookstore.comçeäÄ
+
+staging.inside.nsidc.org+áäÄ
+!
+cucontent.gtm.colorado.edu^ÅäÄ
+
+www-comp.colorado.edubÅäÄ
+
+www.nsidc.orgiáäÄ
+
+integration.nsidc.org+áäÄ
+$
+msf-mars-fw.lasp.colorado.edu3ÉäÄ
+"
+ceasconfluence.colorado.eduRaäÄ
+
+cips.colorado.educmäÄ
+
+www.nsidc.org+áäÄ
+
+mycuhub.colorado.eduÄäÄ
+
+mygroups.colorado.eduéÅäÄ
+"
+cucontent-spsc.colorado.edu^ÅäÄ
+!
+lasp-registry.colorado.eduÉäÄ
+
+cuconnect.colorado.eduíÅäÄ
+
+phet-direct.colorado.edu"ÅäÄ
+
+cires1.colorado.eduàäÄ
+
+ciresblogs.colorado.eduFàäÄ
+
+	nsidc.org+áäÄ
+!
+identikey.gtm.colorado.eduyÅäÄ
+
+phet.colorado.eduÅäÄ
+*
+#external-identikey.gtm.colorado.eduyÅäÄ
+!
+staging.extranet.nsidc.org+áäÄ
+
+ciresgroups.colorado.edu’àäÄ
+
+bioserve.colorado.eduç\äÄ
+
+integration.nsidc.orgiáäÄ
+ 
+mygroups.gtm.colorado.eduéÅäÄ
+
+cires.colorado.edu3àäÄ
+"
+identikey-comp.colorado.eduyÅäÄ
+
+lcd-www.colorado.edu≥çäÄ
+
+mycuinfo.colorado.eduóÅäÄ
+
+www.nsidc.org+áäÄ
+
+k2.colorado.edu+áäÄ
+
+	lasp.linkÉäÄ
+!
+staging.extranet.nsidc.org+áäÄ
+
+mycuboulder.colorado.edu9ÅäÄ
+*
+#cires-eo-virtual-tours.colorado.eduXàäÄ
+
+igloo.nsidc.orgiáäÄ
+
+staging.inside.nsidc.org+áäÄ
+
+igacproject.org`àäÄ
+#
+lasp-auth-stage.colorado.edu#ÉäÄ
+
+igloo.nsidc.org+áäÄ
+
+k2.colorado.edu+áäÄ
+
+achieve.colorado.eduK∑äÄ
+
+staging.nsidc.orgiáäÄ
+
+extranet.nsidc.orgiáäÄ
+
+insidethegreenhouse.org‹àäÄ
+
+ciresevents.colorado.edu#àäÄ
+
+igloo.nsidc.org+áäÄ
+
+office365.colorado.edu–ÅäÄ
+
+icacgp-igac2018.org™àäÄ
+
+www.cires.colorado.edu'àäÄ
+
+www-ucb.colorado.edu4ÅäÄ
+
+jilau1.colorado.eduåäÄ
+
+lcd-www.colorado.edu≥çäÄ
+
+fedauth-dev.colorado.edu»ÅäÄ
+
+www.nsidc.orgiáäÄ
+
+	nsidc.orgiáäÄ
+
+thwaitesglacier.orgjàäÄ
+
+ciresgroups.colorado.eduΩàäÄ
+
+solarz.colorado.edu≥çäÄ
+!
+staging.extranet.nsidc.orgiáäÄ
+
+k2.colorado.eduiáäÄ
+
+mecco.colorado.eduÚàäÄ
+
+integration.nsidc.orgiáäÄ
+
+colorado.edu£ÅäÄ
+
+qa.nsidc.orgiáäÄ
+
+staging.nsidc.orgiáäÄ
+!
+sciencepolicy.colorado.eduÎàäÄ
+ 
+phet-api-dev.colorado.eduMÅäÄ
+
+jila.colorado.eduåäÄ
+
+lst-gve.colorado.edu∏äÄ
+
+oitcup.colorado.edu‹∑äÄ
+
+cires.colorado.edu'àäÄ
+$
+cewebserver-prod.colorado.eduJ∑äÄ
+
+integration.nsidc.org+áäÄ
+
+solarz.colorado.edu≥çäÄ
+
+staging.nsidc.org+áäÄ
+
+ciresgroups.colorado.eduôàäÄ
+!
+staging.extranet.nsidc.orgiáäÄ
+"
+oitcup-upgrade.colorado.edu‹∑äÄ
+#
+legacy-content1.colorado.edu∏äÄ
+ 
+achieve-test.colorado.eduK∑äÄ
+
+lcd-www.colorado.edu≥çäÄ
+
+jilau1.colorado.eduåäÄ
+
+seec.colorado.edu∏äÄ
+
+inside.nsidc.orgiáäÄ
+
+geomag.colorado.eduàäÄ
+
+	buff.link∏äÄ
+%
+test-ecee-jupyter.colorado.edu4∏äÄ
+#
+insideu-staging.colorado.edu∑äÄ
+
+cewebserver.colorado.eduJ∑äÄ
+
+inside.nsidc.orgiáäÄ
+
+ciresgroups.colorado.eduàäÄ
+
+cires.colorado.eduàäÄ
+
+solarz.colorado.edu≥çäÄ
+
+riverware.org∏äÄ
+
+isgw-forum.colorado.edu	ãäÄ
+
+jabber.colorado.edud∏äÄ
+
+alertus.colorado.edu∏äÄ
+
+numberscope.colorado.eduñäÄ
+
+sci.colorado.edu∑äÄ
+
+huey.colorado.eduè∑äÄ
+
+lcd.colorado.edu≥çäÄ
+
+www.cires.colorado.edu3àäÄ
+
+aahvrc.colorado.edu∏äÄ
+
+qa.nsidc.orgiáäÄ
+
+solarz.colorado.edu≥çäÄ
+
+cmci.colorado.edu)∏äÄ
+
+co-lsen.colorado.eduÛàäÄ
+
+cucontent.colorado.edu∏äÄ
+
+lcd.colorado.edu≥çäÄ
+
+ucb-alertus.colorado.edu∏äÄ
+
+earthlab.colorado.edu°àäÄ
+#
+lst-fusion-sand.colorado.edu#∏äÄ
+#
+lawlegacy-dev01.colorado.edu∑äÄ
+
+jilau1.colorado.eduåäÄ
+
+breeze.colorado.edu∏äÄ
+
+insidecires.colorado.eduBàäÄ
+&
+droughtindexportal.colorado.eduªàäÄ
+
+jabber.colorado.edud∏äÄ
+!
+lawinnovation.colorado.edu∏äÄ
+
+zabbix.cs.colorado.edu∏äÄ
+
+tmilab.colorado.eduïäÄ
+
+ofa-web01.colorado.edu∞∏äÄ
+
+lcd-www.colorado.edu≥çäÄ
+
+law-web.colorado.edu∏äÄ
+
+crown-web1.colorado.edu∑äÄ
+
+igloo.nsidc.orgiáäÄ
+
+ciresgroups.colorado.eduqàäÄ
+
+statgen.colorado.eduãäÄ
+
+exp-c.int.colorado.edud∏äÄ
+
+jilau1.colorado.eduåäÄ
+"
+reg-docint-dev.colorado.eduV∏äÄ
+
+exp-c.int.colorado.edud∏äÄ
+
+cmciserver1.colorado.edu)∏äÄ
+
+lcd.colorado.edu≥çäÄ
+
+lawlegacy.colorado.edu∑äÄ
+#
+test-lawlibrary.colorado.edu∑äÄ
+
+int.colorado.edud∏äÄ
+
+www.riverware.org∏äÄ
+"
+physicscourses.colorado.edu7∏äÄ
+
+regina.colorado.eduT∏äÄ
+
+jilau1.colorado.eduåäÄ
+
+ofa.colorado.edu∞∏äÄ
+
+cuexpress.colorado.edud∏äÄ
+
+bouldersolarreu.comª∏äÄ
+
+secs.oakland.edu“ç
+
+igp.colorado.edu1†äÄ
+'
+ reg-docinternal-dev.colorado.eduV∏äÄ
+
+oakland.eduT“ç
+$
+cubouldersurplus.colorado.eduE∏äÄ
+
+exp-e.int.colorado.edud∏äÄ
+
+oakland.edu“ç
+
+lcd.colorado.edu≥çäÄ
+
+colorado.edud∏äÄ
+
+solarz.colorado.edu≥çäÄ
+
+cuexpress.colorado.edud∏äÄ
+
+ciresgroups.colorado.eduõàäÄ
+
+ofainternal.colorado.edu∞∏äÄ
+ 
+trailsparrow.colorado.edu3òäÄ
+
+career-web.colorado.eduØ∏äÄ
+
+int.colorado.edud∏äÄ
+
+oakland.eduY“ç
+
+lcd.colorado.edu≥çäÄ
+
+studentjobs.colorado.edu∞∏äÄ
+
+ip.kaptivo.liveM´—ç
+
+galaxy.phy.cmich.edu1§—ç
+
+oakland.edu&“ç
+
+morse.colorado.eduJ∏äÄ
+
+oakland.edu|“ç
+
+int.colorado.edud∏äÄ
+
+colorado.edud∏äÄ
+
+exp-e.int.colorado.edud∏äÄ
+
+aac.colorado.eduØ∏äÄ
+!
+reg-webarch01.colorado.eduU∏äÄ
+
+umflint.edupÿç
+
+insideu.colorado.edu∑äÄ
+
+oakland.eduN“ç
+
+cms.cmich.edu£—ç
+
+tlstest.vpnalyzer.comÇ{‘ç
+ 
+ecee-jupyter.colorado.edu4∏äÄ
+
+daxlab.colorado.edu"“äÄ
+
+labanywhere.umflint.edu/
+ÿç
+
+oakland.edu“ç
+
+jabber.colorado.edud∏äÄ
+
+oakland.eduÿ“ç
+
+cs-zabbix.colorado.edu∏äÄ
+
+marge.colorado.eduu·äÄ
+
+umflint.edulÿç
+
+cuexpress.colorado.edud∏äÄ
+
+exp-e.int.colorado.edud∏äÄ
+
+oakland.eduI“ç
+
+oakland.edup“ç
+
+umflint.edu»ÿç
+
+sm-pub.cmich.edu©—ç
+
+reg-docint.colorado.eduT∏äÄ
+!
+botanydb-test.colorado.eduÖƒäÄ
+
+	cmich.edu§—ç
+#
+reg-docinternal.colorado.eduT∏äÄ
+
+lawlibrary.colorado.edu∑äÄ
+
+reg.colorado.eduT∏äÄ
+
+ucb-direct.colorado.eduæ∏äÄ
+
+greatlakeswetlands.org≥Ø—ç
+#
+its-targaryen-da.umflint.edu,
+ÿç
+
+	cmich.edu©—ç
+
+arcgis-db.umflint.edu
+ÿç
+
+oakland.eduU“ç
+!
+daxlab-imac20.colorado.edu"“äÄ
+
+loc.vpnalyzer.netŸ{‘ç
+#
+catalog-archive.colorado.eduU∏äÄ
+
+oakland.edul“ç
+
+sunapsis4.umflint.edu'
+ÿç
+
+Expressway-E-1.cmich.edu§—ç
+
+pitserver.colorado.eduƒäÄ
+
+	cmich.edu©—ç
+
+view7-gw1.umflint.edub
+ÿç
+
+tlstest.vpnalyzer.comÖ{‘ç
+#
+cuservices-prod.colorado.eduL∏äÄ
+
+oakland.edu“ç
+
+fluid.colorado.eduÔäÄ
+
+oakland.edu““ç
+
+view7-br2.umflint.edu/
+ÿç
+
+umflint.edumÿç
+
+view7-comp.umflint.edu/
+ÿç
+
+view7-gw1.umflint.edu/
+ÿç
+
+oakland.edum“ç
+
+jabber-guest.cmich.edu§—ç
+
+oakland.eduZ“ç
+
+kelp.colorado.edu"“äÄ
+#
+sam-downloads01.colorado.eduL∏äÄ
+
+oakland.eduu“ç
+
+cuservices.colorado.eduL∏äÄ
+
+tlstest.vpnalyzer.comÉ{‘ç
+
+cms.cmich.edu§—ç
+
+umflint.eduÿç
+
+oakland.edu{“ç
+
+oakland.eduq“ç
+
+botanydb.colorado.eduÖƒäÄ
+
+oakland.eduÿ“ç
+
+psr.vpnalyzer.com„{‘ç
+#
+its-targaryen-da.umflint.edu-
+ÿç
+
+masala.colorado.edu∫äÄ
+
+oakland.edu>»“ç
+
+sm-pub.cmich.edu©—ç
+
+	cmich.edu©—ç
+
+exp-c.int.colorado.edud∏äÄ
+
+ia-lab.colorado.eduu·äÄ
+
+suda.colorado.edu„äÄ
+
+oakland.edu‘“ç
+
+oakland.edu˝“ç
+
+se.cmich.eduÜØ—ç
+
+psr.vpnalyzer.comÂ{‘ç
+
+oakland.edu“ç
+
+www.bouldersolarreu.comª∏äÄ
+
+tlstest.vpnalyzer.comÅ{‘ç
+
+loc.vpnalyzer.netÿ{‘ç
+
+psr.vpnalyzer.comÊ{‘ç
+
+jabber-guest.cmich.edu£—ç
+
+view7-br2.umflint.edu/
+ÿç
+
+oakland.eduM“ç
+
+tlstest.vpnalyzer.com~{‘ç
+
+psr.vpnalyzer.comÁ{‘ç
+
+sm-pub.cmich.edu©—ç
+
+labanywhere.umflint.edu/
+ÿç
+
+view7-gw2.umflint.edu/
+ÿç
+
+Expressway-E-1.cmich.edu£—ç
+
+sunapsis.umflint.edu'
+ÿç
+
+view7-gw1.umflint.edu/
+ÿç
+
+view7-br1.umflint.edu/
+ÿç
+
+view7-db.umflint.edu/
+ÿç
+
+cucfl2.umflint.edu»ÿç
+
+bor.colorado.edu*÷äÄ
+
+view7-int2.umflint.edu/
+ÿç
+
+psr.vpnalyzer.comÍ{‘ç
+
+view7-br1.umflint.edu/
+ÿç
+
+oakland.edu“ç
+
+viewgw.umflint.edub
+ÿç
+
+viewlb.umflint.edub
+ÿç
+
+labanywhere.umflint.edub
+ÿç
+
+loc.vpnalyzer.net◊{‘ç
+
+loc.vpnalyzer.net›{‘ç
+
+oakland.edu`“ç
+
+www.sm-pub.cmich.edu©—ç
+
+view7-gw1.umflint.edub
+ÿç
+
+view7-comp.umflint.edub
+ÿç
+
+	wayne.edu Ÿç
+
+its-ems.umflint.eduh
+ÿç
+
+meow.vpnalyzer.com2{‘ç
+
+loc.vpnalyzer.netﬂ{‘ç
+
+viewlb.umflint.edu/
+ÿç
+
+view7-comp.umflint.edu/
+ÿç
+
+view7-int1.umflint.edub
+ÿç
+
+view7-int2.umflint.edu/
+ÿç
+
+oakland.edu÷“ç
+
+psr.vpnalyzer.com‚{‘ç
+
+arcgis-web.umflint.eduJ
+ÿç
+)
+"assessments.clust.secs.oakland.eduÖ“ç
+
+labanywhere.umflint.educ
+ÿç
+
+secs.oakland.edu]“ç
+
+view7-int1.umflint.edu/
+ÿç
+
+secs.oakland.edu|“ç
+
+flintmap.umflint.eduJ
+ÿç
+
+view7-db.umflint.edu/
+ÿç
+
+viewlb.umflint.edu/
+ÿç
+
+psyclinicti.ad.wayne.edu Ÿç
+
+	wayne.eduK Ÿç
+
+viewgw.umflint.edub
+ÿç
+
+	wayne.edu†Ÿç
+
+view7-gw2.umflint.edub
+ÿç
+
+view7-gw2.umflint.edub
+ÿç
+
+view7-br2.umflint.edub
+ÿç
+
+view7-int2.umflint.educ
+ÿç
+
+csm.wayne.eduŸç
+
+view7-db.umflint.edub
+ÿç
+
+viewgw.umflint.edu/
+ÿç
+
+prod.wayne.edu< Ÿç
+
+tlstest.vpnalyzer.comÄ{‘ç
+
+view7-br2.umflint.educ
+ÿç
+
+view7-gw1.umflint.educ
+ÿç
+
+view7-int1.umflint.edu/
+ÿç
+
+view7-int1.umflint.educ
+ÿç
+
+	cmich.edu£—ç
+
+apps.wayne.edu¥Ÿç
+
+view7-int1.umflint.edub
+ÿç
+
+viewlb.umflint.educ
+ÿç
+
+viewgw.umflint.educ
+ÿç
+
+view7-int1.umflint.educ
+ÿç
+
+umflint.eduKNÿç
+
+git.wayne.edu¢ Ÿç
+
+view7-br1.umflint.edub
+ÿç
+
+degreeworks.wayne.edu¶ Ÿç
+
+view7-gw1.umflint.educ
+ÿç
+
+viewmgr.umflint.educ
+ÿç
+
+viewmgr.umflint.edu/
+ÿç
+
+mapflint.umflint.eduJ
+ÿç
+
+www.vlab.vdi.wayne.edu9Ÿç
+
+loc.vpnalyzer.net‡{‘ç
+
+view7-comp.umflint.educ
+ÿç
+
+view7-gw2.umflint.educ
+ÿç
+
+webmail.wayne.eduK Ÿç
+
+viewmgr.umflint.edu/
+ÿç
+
+view7-db.umflint.educ
+ÿç
+
+viewgw.umflint.educ
+ÿç
+
+viewmgr.umflint.educ
+ÿç
+
+dgwpapp1.prod.wayne.edu¶ Ÿç
+
+web4prod.wayne.edu∆Ÿç
+$
+acquisition.library.wayne.eduèŸç
+
+view7-br1.umflint.educ
+ÿç
+
+view7-int2.umflint.educ
+ÿç
+
+view7-br1.umflint.educ
+ÿç
+#
+www.psyclinicti.ad.wayne.edu Ÿç
+
+labanywhere.umflint.educ
+ÿç
+
+view7-comp.umflint.educ
+ÿç
+
+apps.wayne.edu4Ÿç
+
+viewlb.umflint.edub
+ÿç
+
+	wayne.eduK Ÿç
+
+view7-br1.umflint.edub
+ÿç
+
+viewgw.umflint.edu/
+ÿç
+
+view7-comp.umflint.edub
+ÿç
+
+view7-br2.umflint.edub
+ÿç
+
+view7-int2.umflint.edub
+ÿç
+
+ssomgr.prod.wayne.eduÀŸç
+
+svn.wayne.edu•Ÿç
+
+view7-int2.umflint.edub
+ÿç
+
+view7-gw2.umflint.edu/
+ÿç
+*
+#www.researchtraining.ovpr.wayne.eduŸç
+
+www.research2.wayne.edu0Ÿç
+
+webmail.wayne.eduK Ÿç
+
+view7-db.umflint.educ
+ÿç
+
+labanywhere.umflint.edub
+ÿç
+
+vlab.vdi.wayne.edu9Ÿç
+
+view7-br2.umflint.educ
+ÿç
+
+www.elahi.wayne.eduôŸç
+
+cc.wayne.eduñ Ÿç
+
+www.vlab.vdi.wayne.edu9Ÿç
+
+view7-gw2.umflint.educ
+ÿç
+
+banwkfp1.prod.wayne.edu…Ÿç
+
+viewlb.umflint.educ
+ÿç
+
+www.research2.wayne.edu/Ÿç
+
+www.lib3.lib.wayne.eduËŸç
+
+online.oiss.wayne.eduPŸç
+$
+quicksearch.library.wayne.edu˙Ÿç
+
+dlxs.library.wayne.edu¿Ÿç
+!
+projects.library.wayne.edu~Ÿç
+
+viewmgr.umflint.edub
+ÿç
+
+luna.library.wayne.edu¿Ÿç
+#
+facilities.library.wayne.edu~Ÿç
+
+ods.wayne.edu∆Ÿç
+
+idp.wmich.edu.⁄ç
+
+gowmu.wmich.edu2⁄ç
+"
+dashboard.library.wayne.eduèŸç
+
+vega2.library.wayne.edu˙Ÿç
+"
+dashboard.library.wayne.edu¿Ÿç
+
+research2.wayne.edu0Ÿç
+
+	wayne.edu› Ÿç
+
+banssbp1.prod.wayne.edu∆Ÿç
+ 
+digital.library.wayne.edu¿Ÿç
+
+	wayne.eduêŸç
+ 
+www.online.oiss.wayne.eduPŸç
+
+dgwpapp1.prod.wayne.edu¶ Ÿç
+
+	wayne.eduv Ÿç
+
+med.wayne.eduxŸç
+
+viewmgr.umflint.edub
+ÿç
+!
+projects.library.wayne.edu¿Ÿç
+
+www.csm.wayne.eduŸç
+#
+www.literaryworlds.wmich.edury⁄ç
+
+	wayne.edu…Ÿç
+!
+www.projects.lib.wayne.edu-¨Ÿç
+
+wfts1.wmupd.wmich.eduJ⁄ç
+
+support.wmich.edu"™⁄ç
+
+	wayne.eduú Ÿç
+
+luna.library.wayne.edu~Ÿç
+$
+literaryworlds.coas.wmich.edury⁄ç
+&
+archivematica.library.wayne.edu˙Ÿç
+ 
+digital.library.wayne.edu~Ÿç
+
+	wayne.eduÀŸç
+
+lib3.lib.wayne.eduËŸç
+
+degreeworks.wayne.edu¶ Ÿç
+ 
+combine.library.wayne.edu¿Ÿç
+%
+neefreservations.lib.wayne.eduﬁŸç
+
+med.wayne.eduâŸç
+
+dlxs.library.wayne.edu~Ÿç
+
+courseval.umflint.edutÿç
+
+research2.wayne.edu/Ÿç
+ 
+www.rs4.reuther.wayne.eduBpŸç
+
+research2.wayne.edu0Ÿç
+
+clearpass.tc.mtu.eduÀ@€ç
+
+funds.library.wayne.edu¿Ÿç
+
+www.reuther.wayne.eduÁŸç
+
+dgwpapp1.prod.wayne.edu¶ Ÿç
+)
+"www.neefreservations.lib.wayne.eduﬁŸç
+#
+facilities.library.wayne.edu¿Ÿç
+$
+acquisition.library.wayne.edu¿Ÿç
+
+www.research2.wayne.edu0Ÿç
+ 
+digital.library.wayne.eduèŸç
+
+workflow.wayne.edu…Ÿç
+
+primavera.mtu.edu=D€ç
+
+elahi.wayne.eduôŸç
+
+www.wmich.eduK⁄ç
+"
+elib7apps.library.wayne.edu˙Ÿç
+
+www.rovernet.mtu.edu.D€ç
+
+degreeworks.wayne.edu¶ Ÿç
+
+vega3.library.wayne.edu˙Ÿç
+
+wfts0.wmupd.wmich.eduH⁄ç
+
+govpn.wmich.edu˝⁄ç
+$
+datacatalog.library.wayne.edu~Ÿç
+
+vega1.library.wayne.edu˙Ÿç
+
+dcatstest.med.wayne.eduàŸç
+
+www.sais.wmich.edu—⁄ç
+
+crsconcore.med.wayne.eduÖŸç
+
+pilot.ceas.wmich.eduå⁄ç
+$
+datacatalog.library.wayne.eduèŸç
+"
+www.ksdevweb.ovpr.wayne.eduãŸç
+
+coeusreports.wayne.edu#Ÿç
+
+www.sm-pub.cmich.edu©—ç
+
+mediasite.wmich.edu*⁄ç
+ 
+clearpass-test.tc.mtu.edu)D€ç
+ 
+combine.library.wayne.edu~Ÿç
+
+alertus.wmupd.wmich.eduE⁄ç
+
+hms.reslife.wmich.edu⁄⁄ç
+
+esrs.wmich.eduP[⁄ç
+
+redirect.wmich.eduJ⁄ç
+
+reuther.wayne.eduÁŸç
+
+brn227.brown.wmich.edury⁄ç
+
+assets.ceas.wmich.edu°ë⁄ç
+
+funds.library.wayne.eduèŸç
+$
+datacatalog.library.wayne.edu¿Ÿç
+$
+acquisition.library.wayne.edu~Ÿç
+
+esem.wmich.eduI⁄ç
+ 
+combine.library.wayne.eduèŸç
+
+status-test.it.mtu.eduí@€ç
+!
+www.coeusreports.wayne.edu#Ÿç
+
+webauth.wmich.edu±⁄ç
+#
+facilities.library.wayne.eduèŸç
+
+repos.ceas.wmich.edu¸ê⁄ç
+!
+projects.library.wayne.eduèŸç
+ 
+dcatsoncore.med.wayne.eduÖŸç
+
+rovernet.mtu.edu.D€ç
+
+slimjim.it.wmich.edu˚⁄ç
+
+elevate.wmich.edu û⁄ç
+
+www.esrs.wmich.eduP[⁄ç
+
+sso.mtu.eduMD€ç
+
+	wmich.eduK⁄ç
+
+clubsecrets.cs.wmich.eduPè⁄ç
+#
+publishing.library.wayne.edu˙Ÿç
+
+rs4.reuther.wayne.eduBpŸç
+
+library.wmich.eduÖ⁄ç
+
+login.library.wayne.edu˙Ÿç
+&
+researchtraining.ovpr.wayne.eduŸç
+ 
+reuther.library.wayne.edu˙Ÿç
+
+www.idm-prod.mtu.eduLD€ç
+
+idp.test.wmich.eduí⁄ç
+
+clearpass03.tc.mtu.eduÀ@€ç
+
+support.it.mtu.eduQD€ç
+
+wdet.org<Ÿç
+
+print.mtu.edu[D€ç
+
+www.print.mtu.edu[D€ç
+
+www.resnet.mtu.edu-D€ç
+
+rpt.sais.wmich.edu”⁄ç
+
+photo.wmupd.wmich.eduN⁄ç
+
+bell.ceas.wmich.eduπå⁄ç
+
+www.idm.mtu.eduLD€ç
+!
+libproxy.library.wmich.eduà⁄ç
+
+crsctest.med.wayne.eduàŸç
+
+resnet.mtu.edu-D€ç
+$
+literaryworlds.coas.wmich.edury⁄ç
+
+fm.wmich.edu–∂⁄ç
+
+print.mtu.edu[D€ç
+
+idm.mtu.eduLD€ç
+
+clearpass01.tc.mtu.edu…@€ç
+
+sais.wmich.edu—⁄ç
+
+mymichigantech.mtu.edubD€ç
+ 
+elib7db.library.wayne.edu˙Ÿç
+
+printing.mtu.educD€ç
+
+redirect.it.mtu.eduœD€ç
+
+govpn.test.wmich.edu˝⁄ç
+
+wiki.ceas.wmich.eduÉë⁄ç
+
+pki-aia.it.mtu.eduJD€ç
+ 
+services-test.lib.mtu.eduPD€ç
+
+groups.it.mtu.eduPF€ç
+
+aspire-dev.cs.mtu.eduxD€ç
+
+raolab.biomed.mtu.eduID€ç
+!
+www.mymichigantech.mtu.edubD€ç
+
+www.parentnet.mtu.eduªF€ç
+!
+www.mymichigantech.mtu.edubD€ç
+!
+www.mymichigantech.mtu.edubD€ç
+
+housing.mtu.eduÎD€ç
+
+print.mtu.edu[D€ç
+
+mymichigantech.mtu.edubD€ç
+
+www.print.mtu.edu[D€ç
+
+bdwdbp.cc.wmich.edu¥⁄ç
+$
+literaryworlds.coas.wmich.edury⁄ç
+
+www.printing.mtu.educD€ç
+
+fm.wmich.eduË∂⁄ç
+
+redmine.ceas.wmich.eduoé⁄ç
+
+wmudps.wmich.eduG⁄ç
+ 
+rail-learning-new.mtu.edu3D€ç
+
+huskycast.mtu.eduªG€ç
+
+vpn.wmupd.wmich.edu(T⁄ç
+
+bssp3.cc.wmich.edu6¥⁄ç
+#
+www.literaryworlds.wmich.edury⁄ç
+
+	m.mtu.edueD€ç
+
+superiorideas.orgfD€ç
+
+tutor.cs.mtu.edunD€ç
+
+deptspanel2.it.mtu.eduPE€ç
+
+mirrorforms.it.mtu.eduÚD€ç
+
+clospanel.it.mtu.eduD€ç
+
+deptspanel2.it.mtu.eduPE€ç
+
+www.mylogin.mtu.eduND€ç
+
+login.mtu.eduUF€ç
+
+clospanel.it.mtu.eduD€ç
+
+www.print.mtu.edu[D€ç
+
+www.courses.mtu.edueF€ç
+
+huskieslive.mtu.eduWF€ç
+
+blackhawk.ceas.wmich.edu–å⁄ç
+
+huskymail.mtu.edu!F€ç
+
+emsweb.mtu.eduvF€ç
+
+banforms.it.mtu.eduˇD€ç
+
+lostbot.it.mtu.eduˆG€ç
+%
+www.rail-learning-test.mtu.edu9E€ç
+
+www.banbuck.mtu.eduNF€ç
+
+idm-prod.mtu.eduLD€ç
+
+jira-test.it.mtu.eduF€ç
+
+www.email.mtu.edu"F€ç
+
+www.mindtrekkers.mtu.eduÓF€ç
+
+www.emsweb.mtu.eduvF€ç
+
+mymichigantech.mtu.edubD€ç
+
+buckforms.it.mtu.eduvD€ç
+
+water.cs.mtu.edu>F€ç
+'
+ www.mymichigantechmirror.mtu.eduF€ç
+
+cshci-dev.mtu.eduF€ç
+
+mtu.eduuF€ç
+
+webta.cs.mtu.eduhD€ç
+
+mylogin.mtu.eduND€ç
+
+www.printing.mtu.educD€ç
+
+www.wmudps.wmich.eduG⁄ç
+
+cchi.mtu.edu{D€ç
+
+google-reset.ascl.netjD€ç
+
+appsanywhere-adm.mtu.eduF€ç
+
+parentnet.mtu.eduªF€ç
+$
+bridge.newapple.trans.mtu.edu‡G€ç
+
+zabbix-prod.it.mtu.edu\F€ç
+$
+libproxydev.library.wmich.edus⁄ç
+
+amp.tc.mtu.eduÛD€ç
+
+deptspanel2.it.mtu.eduPE€ç
+
+
+tc.mtu.edu’G€ç
+
+math.mtu.eduÊD€ç
+
+groups.it.mtu.eduPF€ç
+
+pki-aia-test.it.mtu.edu|D€ç
+
+groups.it.mtu.eduPF€ç
+
+cshwsubmit.cs.mtu.eduoD€ç
+ 
+www.rail-learning.mtu.edu5E€ç
+
+merl.michiganltap.org‡G€ç
+
+secure.mtu.edutF€ç
+
+pages.mtu.eduËF€ç
+
+www.amp.tc.mtu.eduÛD€ç
+
+www.housing.mtu.eduÎD€ç
+
+keypath.courses.mtu.eduÂD€ç
+
+newapple.trans.mtu.edu‡G€ç
+&
+roadsoft.newapple.trans.mtu.edu‡G€ç
+
+www.superiorideas.orgfD€ç
+
+clospanel.it.mtu.eduD€ç
+
+shinyclass.ffr.mtu.edu=F€ç
+
+cshci.cs.mtu.eduG€ç
+
+www.email.mtu.edu#F€ç
+$
+www.wherethehellwasigoing.com´´€ç
+
+www.huskycast.mtu.eduªG€ç
+
+groups.it.mtu.eduPF€ç
+!
+rail-learning-test.mtu.edu9E€ç
+
+www.login.mtu.eduUF€ç
+
+banweb.mtu.eduèF€ç
+
+	gleic.org‡G€ç
+
+mtupg.mtu.edu≠F€ç
+
+michiganltap.org‡G€ç
+
+www.huskieslive.mtu.eduWF€ç
+
+www.mtupg.mtu.edu≠F€ç
+
+huskymail.mtu.edu F€ç
+
+www.login.mtu.eduUF€ç
+
+web.prod.trans.mtu.eduÁD€ç
+
+email.mtu.edu#F€ç
+
+PORTAL1-GEO.SABU.MTU.EDUŸ´€ç
+
+crafty.lugmtu.orgº€ç
+
+email.mtu.edu"F€ç
+!
+www.web.prod.trans.mtu.eduÁD€ç
+
+www.security.mtu.eduÏG€ç
+
+vpn.mtri.org<j€ç
+
+techtracs.it.mtu.edu@G€ç
+
+www.blossom.ffr.mtu.eduµF€ç
+
+deptspanel2.it.mtu.eduPE€ç
+
+nb.it.mtu.edu=G€ç
+
+www.tc.mtu.edu’G€ç
+
+hpc.mtu.edu¬D€ç
+
+www.pages.mtu.eduËF€ç
+
+www.roadsoft.org‡G€ç
+
+collab.sfi.mtu.edu7F€ç
+
+portal1-geo.sabu.mtu.eduŸ´€ç
+
+www.gleic.org‡G€ç
+ 
+www.andrewsstudybible.com œè
+
+
+it.mtu.eduaF€ç
+
+hometracker.cs.mtu.edu?F€ç
+
+vpn.wmtu.mtu.edu
+j€ç
+#
+mymichigantechmirror.mtu.eduF€ç
+
+deptspanel2.it.mtu.eduPE€ç
+"
+ltap.newapple.trans.mtu.edu‡G€ç
+
+banbuck.mtu.eduNF€ç
+"
+www.keypath.courses.mtu.eduÂD€ç
+
+nb2.it.mtu.edu=E€ç
+
+www.secure.mtu.edutF€ç
+
+mindtrekkers.mtu.eduÓF€ç
+
+www.it.mtu.eduaF€ç
+
+login.mtu.eduUF€ç
+
+netdrms01.nispdc.nso.eduxí
+
+techpay.mtu.edu´F€ç
+
+www.syp.mtu.edu•G€ç
+
+portal1-geo.sabu.mtu.eduŸ´€ç
+
+www.techpay.mtu.edu´F€ç
+
+docker.lugmtu.orgº€ç
+
+roadsoft.us‡G€ç
+
+emailinfo.mtu.edu™F€ç
+
+myloan.gvsu.edu=î
+
+techshop.mtu.edu®F€ç
+
+vpn.mtu.eduj€ç
+ 
+www.merl.michiganltap.org‡G€ç
+ 
+wherethehellwasigoing.com´´€ç
+
+events.mtu.edu:F€ç
+
+exchange.andrews.eduóœè
+
+www.roadsoft.us‡G€ç
+
+roadsoft.org‡G€ç
+
+www.emailinfo.mtu.edu™F€ç
+
+cock.lugmtu.orgº€ç
+
+www.huskymail.mtu.edu!F€ç
+
+andrews.eduœè
+
+construct.eecn.mtu.edu1M€ç
+
+courses.mtu.edueF€ç
+
+learningcenters.mtu.edu¥F€ç
+
+nciprelay.lib.mtu.edu∫F€ç
+
+www.techshop.mtu.edu®F€ç
+
+raffle-snat.it.mtu.edu!M€ç
+
+ulysses.calvin.edu
+éjô
+
+panorama.calvin.edu©jô
+
+ctt.mtu.edu‡G€ç
+
+www.emsweb-test.mtu.edulF€ç
+
+www.hymnary.orgájô
+
+andrews.eduñœè
+
+
+nb.mtu.edu=G€ç
+
+vault.cs.mtu.edu/T€ç
+&
+www.loadrating.michiganltap.org‡G€ç
+
+techshop-test.mtu.edu∏F€ç
+
+vso.nso.edu{í
+
+
+calvin.edu-»jô
+
+portal1-geo.sabu.mtu.eduŸ´€ç
+
+theia.cs.calvin.edutjô
+
+www.csa.mtu.eduKG€ç
+
+emsweb-test.mtu.edulF€ç
+
+www.construction.mtu.edu1M€ç
+
+winlab.gvsu.edu=î
+ 
+www.andrewsstudybible.org œè
+
+apps.mtu.educF€ç
+
+s2admin.calvin.edu0»jô
+
+
+calvin.edu<»jô
+$
+www.cardservices-test.mtu.eduOG€ç
+
+calvinseminary.eduâjô
+
+staff.gvsu.eduê=î
+
+
+calvin.eduø|jô
+
+security.mtu.eduÏG€ç
+
+www.bandevel.mtu.edu_F€ç
+
+mirrors.lug.mtu.eduº€ç
+
+www.ctt.mtu.edu‡G€ç
+
+
+lugmtu.orgº€ç
+ 
+www.techshop-test.mtu.edu∏F€ç
+
+andrews.eduñœè
+
+www.techfinder.mtu.edu@G€ç
+
+syp.mtu.edu•G€ç
+
+nispdc.nso.edu=í
+
+exchange.andrews.eduóœè
+
+pa-5220-2.calvin.edu©jô
+
+andrewsstudybible.com œè
+
+nispdc.nso.edu>í
+
+7days.lugmtu.orgº€ç
+
+groups.it.mtu.eduPF€ç
+
+vpn-test.gvsu.eduÖ=î
+
+www.www2.gvsu.eduÇ=î
+
+
+calvin.edu
+Œjô
+
+cherwell.calvin.eduÀjô
+
+s2admin.calvin.edu-»jô
+
+andrews.edu%œè
+
+	delta.edu1ÅÖ°
+
+downloads.it.mtu.eduPG€ç
+
+idphotos.calvin.eduê»jô
+
+construction.mtu.edu1M€ç
+
+www.facweb.gvsu.eduê=î
+!
+filemakerserver.albion.eduz|ì
+
+
+calvin.edu©jô
+
+www.michiganltap.org‡G€ç
+
+andrews.eduóœè
+
+fixablelife.orgÀœè
+
+wcbord-web.calvin.edu<»jô
+
+training.gvsu.eduê=î
+
+pa-vpn-2.calvin.edu©jô
+
+rt.albion.eduF|ì
+
+whammies.calvin.eduÁ|jô
+
+www.training.gvsu.eduê=î
+
+faculty.gvsu.eduê=î
+
+
+calvin.eduÀjô
+
+exchange.andrews.eduñœè
+
+nso.edu~í
+
+iot.cs.calvin.edu√jô
+"
+loadrating.michiganltap.org‡G€ç
+
+www.fixablelife.orgÀœè
+
+nso.virtualsolar.org{í
+
+sam.it.mtu.eduıG€ç
+ 
+construction.eecn.mtu.edu1M€ç
+
+www.calvin.eduî»jô
+
+facweb.gvsu.eduê=î
+
+uphill.calvin.eduî»jô
+
+jobedevkey.calvin.eduU˝jô
+"
+EX2-2019.inside.andrews.eduóœè
+"
+merl.newapple.trans.mtu.edu‡G€ç
+
+
+calvin.edu
+éjô
+
+pa-5220-1.calvin.edu©jô
+
+clack.calvin.edu
+Œjô
+
+exchange.andrews.eduñœè
+
+borg-webmo.calvin.edun¬jô
+
+pa-5220-2.calvin.edu©jô
+
+docs.virtualsolar.orgxí
+
+app.calvin.eduê»jô
+
+PORTAL1-GEO.SABU.MTU.EDUŸ´€ç
+$
+jedha-test.calvinseminary.edu*âjô
+
+origin2.internet2.edu$˝£
+ 
+populi.calvinseminary.edu*âjô
+
+	emich.eduûL§
+
+PORTAL1-GEO.SABU.MTU.EDUŸ´€ç
+
+andrews.eduóœè
+
+msfc.virtualsolar.org{í
+
+vpn-pek.it.mtu.eduj€ç
+
+pa-5220-1.calvin.edu©jô
+
+www.staff.gvsu.eduê=î
+
+
+calvin.eduî»jô
+
+
+calvin.eduê»jô
+
+www2.gvsu.eduÇ=î
+
+cpscadmin.cs.calvin.edu√jô
+
+	emich.edurL§
+
+cherwellmapp.calvin.eduÀjô
+
+emsweb.calvin.eduÁ|jô
+
+jobedev.calvin.eduU˝jô
+"
+EX1-2019.inside.andrews.eduñœè
+
+omd-msu.aglt2.org'Ï)¿
+
+nispdc.nso.eduEí
+
+uturn.calvin.eduéjô
+
+nso.eduií
+
+cherwelldemo.calvin.eduÀjô
+
+origin.internet2.edu$˝£
+
+cartalk.calvin.edu
+Œjô
+
+	emich.eduûL§
+
+pa-vpn-1.calvin.edu©jô
+
+www.learnpdc.orgT˝jô
+
+alma.edu.˙e¿
+
+alma.edu.˙e¿
+
+netdrms02.nispdc.nso.edu{í
+
+pa-5220-2.calvin.edu©jô
+
+brooks.cs.calvin.edu√jô
+
+	emich.edu1ûL§
+
+radiologypacs.dmc.org»ºãõ
+
+www.faculty.gvsu.eduê=î
+
+	emich.edu{ûL§
+
+andrews.eduœè
+
+alma.edu.˙e¿
+
+
+calvin.eduÁ|jô
+
+andrews.eduñœè
+
+ezproxy.emich.edu7L§
+
+borg.calvin.eduD¬jô
+
+iot.cs.calvin.edu√jô
+
+adfs.calvin.edu»jô
+
+www.apps.baker.edu⁄Pû
+
+alma.edu[˙e¿
+
+	emich.edujûL§
+
+	delta.eduLÖ°
+
+	emich.eduQûL§
+
+lists.incommon.org$˝£
+
+origin2.internet2.edu$˝£
+
+adfs.calvin.edu»jô
+
+aquinas.eduú\¿
+
+	delta.edusÅÖ°
+
+click.calvin.edu
+Œjô
+
+	delta.eduÅÖ°
+
+	delta.eduûÅÖ°
+
+	emich.edu¥ûL§
+
+	delta.eduòÅÖ°
+
+	delta.eduùÅÖ°
+
+andrews.eduóœè
+
+	emich.edubûL§
+
+aquinas.edu3\¿
+
+alma.edu.˙e¿
+ 
+www.radiologypacs.dmc.org»ºãõ
+#
+psconfig.opensciencegrid.orgiÏ)¿
+
+ezproxy.delta.edunÅÖ°
+
+	emich.eduêL§
+
+synology.delta.edusÅÖ°
+
+	emich.eduûL§
+
+hymnary.orgájô
+
+
+calvin.edu»jô
+
+origin1.internet2.edu$˝£
+
+pdcbook.calvin.eduT˝jô
+
+fluxqc.kbs.msu.edujºl¿
+
+	emich.eduûL§
+!
+filemakerserver.albion.eduz|ì
+
+
+calvin.eduéjô
+
+alma.edu	˙e¿
+
+	delta.eduÅÅÖ°
+
+origin1.internet2.edu$˝£
+
+	emich.edu	ûL§
+
+cherwelltest.calvin.eduÀjô
+
+apps.baker.edu⁄Pû
+
+pa-vpn-1.calvin.edu©jô
+
+
+calvin.edu©jô
+
+uturn.calvin.eduéjô
+
+	delta.eduõÅÖ°
+
+origin.internet2.edu$˝£
+
+	emich.edu≤ûL§
+
+sl-um-ps01-bw.slateci.ioÁ)¿
+
+getconnected.calvin.edu
+Œjô
+
+pa-vpn-1.calvin.edu©jô
+
+	emich.edu[ûL§
+
+alma.edu.˙e¿
+
+cherwelldev.calvin.eduÀjô
+
+www4.gvsu.eduê=î
+
+alma.edu[˙e¿
+
+deltavpn.delta.eduÅÅÖ°
+
+jobe.calvin.eduU˝jô
+
+alma.edu/˙e¿
+
+	mylmc.orgDhm¿
+
+	delta.eduÅÖ°
+
+	delta.edu%ÅÖ°
+
+	emich.eduWL§
+
+datanuggets.org’qÁ¿
+
+sl-um-ps01.slateci.ioÁ)¿
+
+lakemichigancollege.edu˛hm¿
+
+panorama.calvin.edu©jô
+
+alma.edu.˙e¿
+
+learnpdc.orgT˝jô
+
+panorama.calvin.edu©jô
+
+alma.edu.˙e¿
+
+	emich.edu1ûL§
+
+	emich.eduµL§
+
+	emich.eduªûL§
+
+ezproxy.emich.edu7L§
+
+
+calvin.edu©jô
+
+alma.edu.˙e¿
+
+alma.edu-˙e¿
+
+images.apple.com¢∫z¿
+
+	delta.eduúÅÖ°
+
+images.apple.com§∫z¿
+
+xn--ngstr-lra8j.comXπz¿
+
+	delta.edu!ÅÖ°
+
+	emich.eduQûL§
+
+learningspace.delta.eduLÖ°
+
+alma.edu.˙e¿
+
+lakemichigancollege.eduhm¿
+
+	emich.edu´ûL§
+
+aquinas.eduå\¿
+
+	emich.edu6L§
+
+vmbg.alma.edu[˙e¿
+
+pa-vpn-2.calvin.edu©jô
+
+	mylmc.orgIhm¿
+
+psumvm02.aglt2.org*Á)¿
+
+	delta.edu1ÅÖ°
+%
+meshconfig.opensciencegrid.orgiÏ)¿
+
+psumvm01.aglt2.org-Á)¿
+
+jenkins.csel.io;∆
+
+	emich.eduóL§
+
+	delta.edu†ÅÖ°
+
+	emich.edu	ûL§
+
+lter.kbs.msu.eduÓºl¿
+
+alma.edu-˙e¿
+
+omd.aglt2.org˝Á)¿
+
+pa-5220-1.calvin.edu©jô
+
+lakemichigancollege.edu hm¿
+
+	delta.eduåÅÖ°
+
+	emich.edu=L§
+
+vmbg.alma.edu[˙e¿
+
+sl-um-ps01-bw.slateci.ioÛÁ)¿
+
+plv.cs.colorado.edu
+;∆
+
+
+calvin.edu»jô
+
+lakemichigancollege.eduGhm¿
+#
+psconfig.opensciencegrid.orgiÏ)¿
+
+mcc.eduO£ô¿
+
+kettering.edu2âä¿
+
+aquinas.edu¢\¿
+&
+registration.refraction.network|æz¿
+
+phd.cs.colorado.edu
+;∆
+
+cumulus.rc.colorado.eduå;∆
+
+kettering.eduââä¿
+
+www.cs.colorado.edu
+;∆
+
+epic.cs.colorado.edu
+;∆
+
+vmbg.alma.edu[˙e¿
+
+alma.edu.˙e¿
+!
+foundation.cs.colorado.edu;∆
+
+oshtemo.kbs.msu.eduÁqÁ¿
+
+alma.eduv˙e¿
+%
+meshconfig.opensciencegrid.orgiÏ)¿
+
+kettering.eduââä¿
+
+iot.cs.calvin.edu√jô
+
+gprpc32.kbs.msu.eduMºl¿
+
+pl.cs.colorado.edu
+;∆
+
+mfm.colorado.edu
+;∆
+
+alma.edu\˙e¿
+
+www.lter.kbs.msu.eduÓºl¿
+
+alma.edu	˙e¿
+
+psconfig.aglt2.orgiÏ)¿
+
+	emich.edu÷ûL§
+
+inginious.csel.io%;∆
+
+vmbg.alma.edu[˙e¿
+
+home2.cs.colorado.edu(;∆
+
+hcc.cs.colorado.edu
+;∆
+
+dev.grafana.csel.io;∆
+
+kettering.eduõâä¿
+
+redirector.colorado.edu
+;∆
+
+images.apple.com∞∫z¿
+
+vpn-tcom.colorado.edu%7;∆
+
+houghton.kbs.msu.edu qÁ¿
+
+home3.cs.colorado.edu(;∆
+
+cloud.cs.colorado.eduÜ;∆
+
+csel-web.cs.colorado.edu;∆
+
+pnd.colorado.edu;∆
+
+autonomy.colorado.edu
+;∆
+ 
+runestone.cs.colorado.edu$;∆
+
+lakemichigancollege.eduhm¿
+
+kettering.eduõâä¿
+
+lakemichigancollege.edu1hm¿
+ 
+pondhawk.knet.kbs.msu.edu†qÁ¿
+
+lter.msu.eduÓºl¿
+
+alma.edu.˙e¿
+
+inginious.colorado.edu%;∆
+
+workspace.mcc.eduD£ô¿
+
+vpn.colorado.edu&7;∆
+ 
+wkuf-router.kettering.edué¸ı¿
+
+wkuf.fm
+¿†¿
+
+kettering.edu2âä¿
+%
+cs2400-applied.cs.colorado.edu";∆
+$
+play-lh.googleusercontent.comXπz¿
+"
+applied-sql.cs.colorado.edu1;∆
+
+vpn-tcom.colorado.edu&7;∆
++
+$cite-worthiness.scienceofscience.org—F;∆
+
+vmbg.alma.edu[˙e¿
+
+correll.cs.colorado.edu
+;∆
+
+vpn-tcom.colorado.eduÀ7;∆
+ 
+inginious.cs.colorado.edu%;∆
+
+home.cs.colorado.edu(;∆
+
+cs2400.cs.colorado.edu!;∆
+
+jupyter.cs.colorado.edu
+;∆
+
+cloud.cs.colorado.eduÜ;∆
+
+aaof-gw-fin.merit.edul∆
+
+focs.cs.colorado.edu+;∆
+
+lakemichigancollege.edu7hm¿
+
+moodle.cs.colorado.edu#;∆
+
+images.apple.com£∫z¿
+
+vpn2.colorado.edu%7;∆
+
+spinks.kbs.msu.edu;qÁ¿
+
+applied.cs.colorado.edu4;∆
+
+vpn.colorado.edu%7;∆
+
+cloud.cs.colorado.eduÜ;∆
+*
+#ondemand-devidp.rc.int.colorado.edu3;∆
+
+kettering.eduõâä¿
+
+mcc.eduW£ô¿
+
+coding.colorado.edu
+;∆
+
+focs2021.cs.colorado.edu+;∆
+
+csfinance.colorado.edu;∆
+
+focs.colorado.edu+;∆
+
+vpn2.colorado.eduÀ7;∆
+
+runestone.colorado.edu$;∆
+
+thetford.kbs.msu.edu¯qÁ¿
+
+vpn2.colorado.edu&7;∆
+
+csr.csel.io;∆
+
+vpn-comp.colorado.eduÀ7;∆
+
+cloud.cs.colorado.eduÜ;∆
+
+cloud.cs.colorado.eduÜ;∆
+%
+ondemand-rmacc.rc.colorado.edu3;∆
+ 
+www.museweb.bronsonhg.orgål∆
+
+lakemichigancollege.edu*hm¿
+"
+applied-sql.cs.colorado.edu1;∆
+
+coding.cs.colorado.edu
+;∆
+
+lakemichigancollege.eduFhm¿
+
+vpn-tcom.colorado.edu 7;∆
+
+vpn-comp.colorado.edu 7;∆
+
+vpndev-tcom.colorado.edu∫R;∆
+
+cloud.cs.colorado.eduÜ;∆
+
+vpn-comp.colorado.edu&7;∆
+
+vpndev-comp.colorado.edu∫R;∆
+
+
+vizwiz.org2;∆
+
+kettering.eduââä¿
+
+vpndev2.colorado.edu∫R;∆
+
+www.lter.msu.edu qÁ¿
+
+museweb.bronsonhg.orgål∆
+
+gptest.bronsonhg.orgål∆
+
+cloud.cs.colorado.eduÜ;∆
+!
+rcamp1.rc.int.colorado.edu3;∆
+
+cumulus.rc.colorado.eduå;∆
+
+bluepie.mcc.eduL£ô¿
+
+	mylmc.org3hm¿
+
+vpn2.colorado.edu 7;∆
+
+vpn.colorado.eduÀ7;∆
+
+cumulus.rc.colorado.eduå;∆
+
+rcamp1.rc.colorado.edu3;∆
+
+kettering.eduââä¿
+
+cumulus.rc.colorado.eduå;∆
+
+pondhawk.kbs.msu.edu†qÁ¿
+
+cumulus.rc.colorado.eduå;∆
+
+vizwiz.cs.colorado.edu2;∆
+"
+applied-dev.cs.colorado.edu6;∆
+
+build.cs.colorado.edu;∆
+
+bengine.csel.io#;∆
+
+vpndev.colorado.edu∫R;∆
+
+belt.rc.colorado.edu[S;∆
+
+atlasweb.bronsonhg.orgGål∆
+
+datanuggets.com’qÁ¿
+
+rcamp3.rc.colorado.edu3;∆
+
+kettering.eduΩâä¿
+
+vpn.colorado.edu 7;∆
+"
+applied-sql.cs.colorado.edu1;∆
+
+l3d.colorado.edu“F;∆
+
+bivpriv.colorado.eduêF;∆
+
+cumulus.rc.colorado.eduå;∆
+
+bluepie.mccad.mcc.eduL£ô¿
+
+kettering.eduõâä¿
+
+aaof-gw-fin.merit.edul∆
+
+bronsonhg.orgPål∆
+
+jhub.grafana.csel.ioi;∆
+ 
+mychart.bronsonhealth.comfål∆
+
+cs.colorado.edu
+;∆
+
+aaof-gw-msc.merit.edul∆
+
+cumulus.rc.colorado.eduå;∆
+
+cloud.cs.colorado.eduÜ;∆
+
+ondemand.rc.colorado.edu3;∆
+
+mail.bronsonhg.orgiål∆
+
+aaof-gw-netops.merit.edul∆
+
+cloud.cs.colorado.eduÜ;∆
+
+portals.rc.colorado.edu3;∆
+
+aaof-gw-staff.merit.edul∆
+
+aaof-gw-swdev.merit.edul∆
+
+bronsonhg.org@ål∆
+
+aaof-gw-msc.merit.edul∆
+ 
+rcamp.rc.int.colorado.edu3;∆
+
+cumulus.rc.colorado.eduå;∆
+
+rcamp.rc.colorado.edu3;∆
+
+xdmod.rc.colorado.edu3;∆
+!
+autodiscover.bronsonhg.orgiål∆
+
+volunteers.bronsonhg.orgjål∆
+
+aaof-gw-netops.merit.edul∆
+
+bronsonhg.orgçl∆
+
+bronsonhg.org±ål∆
+
+smtp.bronsonhg.orgiål∆
+'
+ rstudio-bootcamp.rc.colorado.eduS;∆
+
+bronsonhg.org∞ål∆
+
+mychart.wmed.eduwål∆
+
+aaof-gw-it.merit.edul∆
+
+wmed.edu˚îl∆
+
+wmed.edu2îl∆
+
+bronsonhg.orgOål∆
+"
+bmhepichwsx03.bronsonhg.org¢çl∆
+#
+www.volunteers.bronsonhg.orgjål∆
+
+vpn-comp.colorado.edu%7;∆
+
+www.testmvd.borgess.com-èl∆
+"
+bmhepichwsx06.bronsonhg.org¢çl∆
+
+hygieia.bronsonhg.orgsål∆
+
+
+ncmich.edu¿l∆
+
+aaof-gw-staff.merit.edul∆
+%
+mychartsched.bronsonhealth.comfål∆
+ 
+pdctemptrak.bronsonhg.orgål∆
+"
+bmhepichwsx10.bronsonhg.org¢çl∆
+
+bronsonhg.orgVål∆
+"
+bmhepichwsx04.bronsonhg.org¢çl∆
+
+aaof-gw-it.merit.edul∆
+
+dbd.sh‡Ml∆
+
+bhgvpn.bronsonhg.orgål∆
+
+cloud.cs.colorado.eduÜ;∆
+
+cumulus.rc.colorado.eduå;∆
+
+aaof-gw-it.merit.edul∆
+
+aaof-gw-fin.merit.edul∆
+
+aaof-gw-netops.merit.edul∆
+"
+bmhepichwsx02.bronsonhg.org¢çl∆
+!
+epiccarelink.bronsonhg.orgål∆
+
+mercury.bronsonhg.orgtål∆
+
+cloud.cs.colorado.eduÜ;∆
+
+vmbg-lan.nmc.eduø«l∆
+
+ezaccess.borgess.com≤èl∆
+
+
+mymcls.comHbl∆
+
+bronsonhg.orgHçl∆
+
+med.wmich.eduîl∆
+
+cumulus.rc.colorado.eduå;∆
+
+vpn.merit.edul∆
+
+mercury.bronsonhg.orgtål∆
+
+vpn.merit.edul∆
+
+aaof-gw-sec.merit.edul∆
+"
+bmhepichwsx08.bronsonhg.org¢çl∆
+
+catalog.tadl.orgG⁄l∆
+
+guac-1.tadl.orgF⁄l∆
+!
+rcamp3.rc.int.colorado.edu3;∆
+
+bronsonhg.orgål∆
+
+aaof-gw-sec.merit.edul∆
+
+aaof-gw-swdev.merit.edul∆
+
+www.mychart.wmcc.org¶çl∆
+
+aaof-gw-msc.merit.edul∆
+
+imap.bronsonhg.orgiål∆
+
+aaof-gw-swdev.merit.edul∆
+
+micollab.nmc.eduø«l∆
+
+aaof-gw-sec.merit.edul∆
+
+aaof-gw-staff.merit.edul∆
+
+bronsonhg.org∞çl∆
+
+chaos.bronsonhg.orgzål∆
+ 
+www.mychart.avsurgery.com∫çl∆
+
+www.mymcls.comHbl∆
+
+bronsonhg.orgHçl∆
+
+vpn.merit.edul∆
+
+aaof-gw-sec.merit.edul∆
+
+bronsonhg.org†çl∆
+
+dbd.sh‡Ml∆
+
+aaof-gw-staff.merit.edul∆
+
+bronsonhg.org{ål∆
+ 
+slicerdicer.bronsonhg.org¸çl∆
+
+aaof-gw-it.merit.edul∆
+
+bronsonhg.orghçl∆
+
+Security.Adrian.edu
+Pl∆
+
+aaof-gw-fin.merit.edul∆
+"
+bmhepichwsx05.bronsonhg.org¢çl∆
+
+aaof-gw-msc.merit.edul∆
+
+bronsonhg.org≤çl∆
+
+Security.Adrian.edu
+Pl∆
+
+med.wmich.edu˙îl∆
+!
+visualizetst.bronsonhg.orgπçl∆
+"
+bmhepichwsx07.bronsonhg.org¢çl∆
+
+Erebus.bronsonhg.org¢çl∆
+
+www.cteps.dsisd.netÙl∆
+
+mason-oceana911.orgGõl∆
+
+bronsonhg.orgål∆
+
+vmbg-lan.nmc.eduø«l∆
+!
+bmhcogitosd2.bronsonhg.org¸çl∆
+
+fhckzoo.comâål∆
+
+vmbg-lan.nmc.eduø«l∆
+
+mychart.avsurgery.com∫çl∆
+
+landesk.bronsonhg.orgål∆
+!
+bmhcogitosd1.bronsonhg.org¸çl∆
+
+www.mychart.kzoo.edu6çl∆
+
+www.iconnect.borgess.comQèl∆
+&
+ondemand-devidp.rc.colorado.edu3;∆
+
+med.wmich.eduîl∆
+
+cteps.dsisd.netÙl∆
+
+ntwps.dsisd.net7Ùl∆
+
+iconnect.borgess.comQèl∆
+
+www.brhps.dsisd.net4Ùl∆
+
+zuercherportal.comLõl∆
+
+bronsonhg.org±çl∆
+
+mercury.bronsonhg.orgtål∆
+
+mail.menomineeco.comÒl∆
+
+bronsonhg.orgëål∆
+
+mychart.kzoo.edu6çl∆
+
+ica.apps.tadl.orga⁄l∆
+
+mail.deltacountymi.orgd˝l∆
+"
+bmhepichwsx01.bronsonhg.org¢çl∆
+
+fm.adrian.eduRl∆
+
+bronsonhg.orgål∆
+
+rochestermi.org£Ãl∆
+
+aaof-gw-swdev.merit.edul∆
+%
+www.visualizetst.bronsonhg.orgπçl∆
+$
+www.pdctemptrak.bronsonhg.orgål∆
+
+mpsps.dsisd.net3Ùl∆
+
+visualize.bronsonhg.org∏çl∆
+
+catalog.tadl.orgb⁄l∆
+
+bronsonhg.orgíål∆
+
+bronsonhg.orgeçl∆
+
+mychart.med.wmich.eduwål∆
+
+www.mpsps.dsisd.net3Ùl∆
+$
+www.slicerdicer.bronsonhg.org¸çl∆
+
+micollab.nmc.eduø«l∆
+ 
+www.museweb.bronsonhg.orgål∆
+
+menomineeco.comÒl∆
+
+brhps.dsisd.net4Ùl∆
+
+jail.deltacountymi.orgl˝l∆
+
+micollab.menomineeco.com
+Òl∆
+
+www.cteps.dsisd.netÙl∆
+
+bbdps.dsisd.net8Ùl∆
+
+office.deltacountymi.orgi˝l∆
+#
+www.micollab.menomineeco.com
+Òl∆
+
+catalog.tadl.orgo⁄l∆
+
+wmed.eduîl∆
+ 
+mychart.bronsonhealth.comªçl∆
+
+vpn.merit.edul∆
+
+portal.aircare.orgÔîl∆
+
+ebb.opacs.tadl.orgi⁄l∆
+
+testmvd.borgess.com-èl∆
+
+ica.tadl.netr⁄l∆
+%
+mychartsched.bronsonhealth.comªçl∆
+
+bronsonhg.org≤ål∆
+#
+www.micollab.menomineeco.com
+Òl∆
+
+help.deltacountymi.govq˝l∆
+
+ntwps.dsisd.net7Ùl∆
+
+listserver.udmercy.edu	m∆
+
+	remc1.netÇ˝l∆
+
+mason-oceana911.orgHõl∆
+
+micollab.menomineeco.com
+Òl∆
+
+www.mail.menomineeco.comÒl∆
+
+www.zuercherportal.comLõl∆
+
+micollab.nmc.eduø«l∆
+
+newhistory.tadl.orgh⁄l∆
+
+via.tadl.orgv⁄l∆
+
+mychart.wmcc.org¶çl∆
+
+sandbox.dsisd.net<Ùl∆
+
+	remc1.netÉÙl∆
+
+wmed.edu/îl∆
+
+ps.dsisd.net:Ùl∆
+!
+www.mail.deltacountymi.orgd˝l∆
+
+micollab.nmc.eduø«l∆
+
+udmercy.edudm∆
+"
+www.visualize.bronsonhg.org∏çl∆
+
+med.wmich.edu9îl∆
+
+udmercy.edu◊m∆
+
+micollab.menomineeco.com
+Òl∆
+
+brhps.dsisd.net4Ùl∆
+"
+bmhepichwsx09.bronsonhg.org¢çl∆
+#
+www.micollab.menomineeco.com
+Òl∆
+
+www.mpsps.dsisd.net3Ùl∆
+
+www.brhps.dsisd.net4Ùl∆
+
+micollab.menomineeco.com
+Òl∆
+
+mail.menomineeco.comÒl∆
+
+micollab.menomineeco.com
+Òl∆
+
+udmercy.edu¨m∆
+ 
+www.powerschool.dsisd.net=Ùl∆
+
+udmercy.edu!m∆
+
+mail.deltacountymi.govd˝l∆
+
+med.wmich.eduîl∆
+
+micollab.menomineeco.com
+Òl∆
+
+www.mobilmad.madonna.edunHm∆
+
+mpsps.dsisd.net3Ùl∆
+
+vpn.deltacountymi.govb˝l∆
+
+www.sfweb.copesd.orgK‹l∆
+
+mail.deltacountymi.orgd˝l∆
+
+www.ttsps.dsisd.net9Ùl∆
+
+udmercy.edu˙m∆
+
+udmercy.edu	m∆
+
+
+ncmich.edu2¿l∆
+
+vmbg-lan.nmc.eduø«l∆
+
+listserver.udmercy.edu	m∆
+!
+airwatch.deltacountymi.orgf˝l∆
+&
+www.server1.netcomcomputers.com7km∆
+
+udmercy.edu‘m∆
+
+choosests.comkm∆
+
+ica.tadl.nets⁄l∆
+
+cloud.deltacountymi.govi˝l∆
+
+ps.dsisd.net:Ùl∆
+
+cmhmail.scccmha.orgIYm∆
+
+micollab.menomineeco.com
+Òl∆
+!
+www.mail.deltacountymi.orgd˝l∆
+
+admin.legislature.mi.gov¥≠m∆
+ 
+www.powerschool.dsisd.net=Ùl∆
+
+access.scccmh.orgIYm∆
+
+	arbor.edu∏¬m∆
+
+legislature.mi.govØ≠m∆
+ 
+records.deltacountymi.govg˝l∆
+
+micollab.menomineeco.com
+Òl∆
+
+mail.deltacountymi.orgd˝l∆
+
+ttsps.dsisd.net9Ùl∆
+
+mail.deltacountymi.govd˝l∆
+
+www.bbdps.dsisd.net8Ùl∆
+
+powerschool.dsisd.net=Ùl∆
+
+access.scccmha.orgIYm∆
+
+cloud.deltacountymi.orgi˝l∆
+
+mbg.mwse.org(√m∆
+
+autodiscover.scccmha.orgIYm∆
+$
+autodiscover.sienaheights.edu⁄m∆
+
+mail.deltacountymi.govd˝l∆
+
+admin.legislature.mi.govÆ≠m∆
+
+www.ps.dsisd.net:Ùl∆
+
+www.ntwps.dsisd.net7Ùl∆
+
+fm.corbindesign.comIkm∆
+!
+www.mail.deltacountymi.orgd˝l∆
+
+www.sandbox.dsisd.net<Ùl∆
+
+udmercy.eduAm∆
+ 
+www.vpn.deltacountymi.govb˝l∆
+
+www.fm.corbindesign.comIkm∆
+
+ironwood.gogebic.eduÄn∆
+
+udmercy.eduÂm∆
+
+sfweb.copesd.orgK‹l∆
+#
+www.micollab.menomineeco.com
+Òl∆
+
+scccmha.orgIYm∆
+
+mail.deltacountymi.govd˝l∆
+
+jail.deltacountymi.govl˝l∆
+
+mail.sienaheights.edu(⁄m∆
+
+hosted.tadl.orgx⁄l∆
+
+mail.deltacountymi.orgd˝l∆
+
+cteps.dsisd.netÙl∆
+
+ironwood.gogebic.eduíÄn∆
+
+micollab.menomineeco.com
+Òl∆
+
+admin.legislature.mi.gov´≠m∆
+
+www.ttsps.dsisd.net9Ùl∆
+
+mca-2.mwse.org(√m∆
+
+	arbor.edu¬m∆
+
+bbdps.dsisd.net8Ùl∆
+
+www.menomineeco.comÒl∆
+
+ironwood.gogebic.eduÄn∆
+!
+www.mail.deltacountymi.orgd˝l∆
+
+www.ntwps.dsisd.net7Ùl∆
+
+www.rdp.mwse.org-√m∆
+
+med.wayne.eduáGm∆
+
+udmercy.edu™m∆
+
+mail.deltacountymi.orgd˝l∆
+
+ironwood.gogebic.eduÖÄn∆
+
+ironwood.gogebic.edu
+Än∆
+
+fm.corbindesign.comIkm∆
+
+admin.legislature.mi.gov™≠m∆
+
+www.atafordpas.orgym∆
+!
+www.mail.deltacountymi.orgd˝l∆
+
+hillsdalebpu.com√m∆
+
+ironwood.gogebic.eduÉÄn∆
+
+mca.mwse.org(√m∆
+
+miottawa.org	Wn∆
+
+www.scccmh.orgIYm∆
+"
+server1.netcomcomputers.com7km∆
+
+www.ps.dsisd.net:Ùl∆
+
+house.mi.govπ≠m∆
+
+legislature.mi.gov´≠m∆
+
+www.help.jccmi.edu†»m∆
+
+	remc1.netÉÙl∆
+
+ironwood.gogebic.eduFÄn∆
+
+	gisbr.comdên∆
+
+hillsdalebpu.com√m∆
+'
+ www.5ba0d9f8ebb3f.streamlock.net≠m∆
+
+audgen.michigan.gov=≠m∆
+
+www.fm.corbindesign.comIkm∆
+$
+autodiscover.sienaheights.edu(⁄m∆
+ 
+rod.dickinsoncountymi.gov)„m∆
+
+ttsps.dsisd.net9Ùl∆
+
+sandbox.dsisd.net<Ùl∆
+
+med.wayne.edu≈çm∆
+
+legislature.mi.gov¥≠m∆
+
+mbg.mwse.org(√m∆
+
+ironwood.gogebic.eduÅn∆
+#
+www.acctsql.brt.badriver.comdên∆
+
+grdc-view02.merit.edu-tn∆
+
+cmhexchange.scccmha.orgIYm∆
+
+legislature.mi.govÆ≠m∆
+!
+airwatch.deltacountymi.orgf˝l∆
+
+superiorconnections.comdên∆
+
+view2.merit.edu-tn∆
+
+mobilmad.madonna.edunHm∆
+
+acctsql.brt.badriver.comyên∆
+
+badriver-nsn.govyên∆
+
+myuser1.nmu.edu=¿n∆
+&
+www.vpn-specialprojects.ltu.eduƒën∆
+ 
+corbinet.corbindesign.comKkm∆
+
+myuser2.nmu.edu=¿n∆
+
+support.glifwc.org3ên∆
+#
+5ba0d9f8ebb3f.streamlock.net≠m∆
+
+ironwood.gogebic.eduÅn∆
+
+badriver.comyên∆
+ 
+records.deltacountymi.orgg˝l∆
+
+rdp.mwse.org-√m∆
+
+brm.badriver.comdên∆
+
+mbg.mwse.org(√m∆
+
+myuser.nmu.edu=¿n∆
+
+acctsql.brt.badriver.comdên∆
+
+ironwood.gogebic.eduìÄn∆
+
+cmhsecure.scccmh.orgIYm∆
+
+myusr2.nmu.edu=¿n∆
+
+lib.nmu.edu¬n∆
+
+help.jccmi.edu†»m∆
+
+badriverhwc.comdên∆
+
+sienaheights.edu⁄m∆
+
+mbg.mwse.org(√m∆
+
+pinkytest.vai.org
+ßn∆
+
+mlist.nmu.edu«n∆
+
+autodiscover.scccmh.orgIYm∆
+
+ironwood.gogebic.eduîÄn∆
+&
+www.server1.netcomcomputers.com7km∆
+
+brclock.comyên∆
+
+ironwood.gogebic.edu¢Än∆
+
+gis.badriver-nsn.gov{ên∆
+(
+!merit-pdreceiver-prod02.merit.edutn∆
+
+mca-2.mwse.org(√m∆
+
+house.mi.govπ≠m∆
+
+admin.legislature.mi.govØ≠m∆
+
+www.gis.badriver-nsn.gov{ên∆
+
+beaker.nmu.edu«n∆
+
+nmuebs.nmu.edu«n∆
+
+myusr1.nmu.edu=¿n∆
+
+vpn-abroad.ltu.eduÀën∆
+
+ww-library.nmu.edu¬n∆
+
+ezpolson.nmu.edu¬n∆
+
+ittech.nmu.edu«n∆
+
+grdc-view01.merit.edu-tn∆
+
+hillsdalebpu.com√m∆
+
+	myjdl.com˙€m∆
+
+legislature.mi.gov™≠m∆
+$
+www.corbinet.corbindesign.comKkm∆
+
+mbg.mwse.org(√m∆
+
+brclock.comdên∆
+
+
+scccmh.orgIYm∆
+
+enterprise.nmu.edu«n∆
+
+btpl.orgêrm∆
+
+devorientation.nmu.eduH«n∆
+
+	gisbr.comyên∆
+
+brtremote.comdên∆
+
+www.brclock.comdên∆
+"
+server1.netcomcomputers.com7km∆
+
+photo.nmu-media.com»n∆
+
+hillsdalebpu.com
+√m∆
+
+grdc-vsec02.merit.edu-tn∆
+
+brm.badriver.comyên∆
+
+ironwood.gogebic.edu	Än∆
+
+sienaheights.edu(⁄m∆
+
+badriver-nsn.govdên∆
+
+dev.nmu-media.com»n∆
+
+superiorconnections.comyên∆
+
+goccsc.glenoaks.edu„m∆
+
+marbles.nmu.edu»n∆
+
+www.goccsc.glenoaks.edu„m∆
+
+web1.vai.orgTßn∆
+
+alexandria.nmu.edud»n∆
+
+devapply.nmu.eduH«n∆
+
+imginfo.nmu.edu«n∆
+
+nmuebs.nmu.edu«n∆
+
+vpn-test.ltu.eduÃën∆
+
+kettering.edu«n∆
+
+nmu.eduA»n∆
+
+fwvpna.vai.org
+ßn∆
+
+www.vpn-abroad.ltu.eduÀën∆
+
+up200nmu.com»n∆
+
+umcdev1.nmu.edu´Àn∆
+*
+#lyncdiscoverinternal.baycollege.edu!’n∆
+
+internal.nmu.eduG«n∆
+
+webconf1.baycollege.edu‘n∆
+
+listserv.nmu.edu«n∆
+
+mytest.nmu.eduÿ»n∆
+
+news.nmu.eduA»n∆
+
+ezproxy.myjdl.com˝€m∆
+
+rocky.nmu.edu1¿n∆
+
+mbg.mwse.org(√m∆
+
+news.nmu-media.orgA»n∆
+
+www-library3.nmu.edu¬n∆
+
+beaker.nmu.edu«n∆
+
+nmu-media.orgA»n∆
+
+badriver.comdên∆
+
+testvpn.vai.org
+ßn∆
+
+imginfo.nmu.edu«n∆
+
+enterprise.nmu.edu«n∆
+
+mail.sienaheights.edu⁄m∆
+
+oab.baycollege.edu(’n∆
+
+mlshare.nmu.edu«n∆
+
+mapssecconn.mapsnet.org
+«n∆
+
+lstsrv.nmu.edu«n∆
+
+foundation.nmu-media.orgA»n∆
+(
+!autodiscover.sheridanhospital.como∆
+
+www.brclock.comyên∆
+
+
+macomb.eduG8o∆
+
+ittech.nmu.edu«n∆
+"
+vpn-specialprojects.ltu.eduƒën∆
+
+dialin.baycollege.edu!’n∆
+
+umcdev1-dev.nmu.edu´Àn∆
+
+foundation.nmu.eduA»n∆
+#
+www.acctsql.brt.badriver.comyên∆
+
+pinky.vai.org
+ßn∆
+
+mca.mwse.org(√m∆
+
+ike2jj.nmu.eduŒn∆
+
+
+macomb.eduP8o∆
+
+maap.org»n∆
+
+kci-net.karmanos.orgä¯n∆
+
+pigpen.nmu.edu«n∆
+
+
+macomb.eduw8o∆
+
+mailshare.nmu.edu«n∆
+
+wildcast.nmu.eduE«n∆
+
+maap.nmu-media.com»n∆
+#
+schmail.sheridanhospital.como∆
+
+franklin.nmu.eduA»n∆
+
+umcdev1-news.nmu.edu´Àn∆
+
+leo.nmu.eduÿ»n∆
+
+eanasset.nmu.edu$«n∆
+
+ews.baycollege.edu'’n∆
+
+libcal.nmu.edu¬n∆
+
+oab.baycollege.edu)’n∆
+
+brtremote.comyên∆
+
+webconf1.baycollege.edu‘n∆
+
+library.nmu.edu¬n∆
+
+karmanos.orgå¯n∆
+
+atafordpas.orgym∆
+
+ike2km.nmu.eduŒn∆
+$
+www.rod.dickinsoncountymi.gov)„m∆
+
+eas.baycollege.edu'’n∆
+
+northgate.lssu.edu‹n∆
+
+
+macomb.eduö8o∆
+
+idp.nmu.edu1»n∆
+
+
+macomb.edu§8o∆
+
+grdc-vsec01.merit.edu-tn∆
+
+ews.baycollege.edu(’n∆
+
+ctlregister.nmu.edu¬n∆
+
+
+macomb.eduú8o∆
+
+
+macomb.edu≠8o∆
+
+cmssso.nmu.eduê»n∆
+
+outlook.baycollege.edu)’n∆
+
+nmu.college´Àn∆
+
+photo.up200nmu.com»n∆
+
+sheridanhospital.como∆
+
+webconf1.baycollege.edu‘n∆
+
+gitlib.nmu.edu¬n∆
+
+pigpen.nmu.edu«n∆
+"
+lyncdiscover.baycollege.edu!’n∆
+
+nmudrive.nmu.edud»n∆
+
+www-library2.nmu.edu¬n∆
+
+webconf1.baycollege.eduÒ‘n∆
+
+mas.baycollege.edu‘n∆
+!
+umcdev1-foundation.nmu.edu´Àn∆
+&
+securemail.sheridanhospital.com1o∆
+
+skype.baycollege.edu!’n∆
+
+ike2.nmu.eduŒn∆
+&
+securemail.sheridanhospital.com.o∆
+
+baycollege.edu'’n∆
+
+spaces.nmu.edu¬n∆
+
+webconf1.baycollege.edu‘n∆
+
+umc-media.nmu.eduàÀn∆
+
+lyncadmin.baycollege.edu!’n∆
+#
+schspam.sheridanhospital.com1o∆
+
+mram.nmu.edu:«n∆
+
+mail.baycollege.edu)’n∆
+
+nmu-media.com»n∆
+
+www.gateway.holyfam.org>o∆
+
+mail.baycollege.edu'’n∆
+
+clconnect-test.lssu.eduáÿn∆
+&
+securemail.sheridanhospital.como∆
+
+outlook.baycollege.edu(’n∆
+
+www.vpn-test.ltu.eduÃën∆
+
+umcdev4.nmu.edu≈Àn∆
+
+karmanos.org¯n∆
+
+prtg.lssu.eduåÿn∆
+
+kci-net.karmanos.org¯n∆
+
+educat.nmu.eduŒn∆
+
+roundcube.nmu.edu1¿n∆
+&
+securemail.sheridanhospital.como∆
+
+ews.baycollege.edu)’n∆
+
+eas.baycollege.edu+’n∆
+
+meet.baycollege.edu!’n∆
+%
+vpn.dickinsoncountysheriff.net¢◊n∆
+
+webmail.nmu.edu1¿n∆
+
+
+macomb.educ9o∆
+
+thdwebtest.nmu.edu—»n∆
+#
+schspam.sheridanhospital.como∆
+
+apps.nmu.eduG«n∆
+
+
+macomb.eduò8o∆
+
+aquinas.eduÇın∆
+
+sheridanhospital.com2o∆
+
+
+macomb.eduç9o∆
+&
+securemail.sheridanhospital.como∆
+
+sheridanhospital.como∆
+
+mas.baycollege.edu‘n∆
+
+northgate.lssu.edu⁄n∆
+
+baycollege.edu(’n∆
+"
+autodiscover.baycollege.edu'’n∆
+
+rhpl.orgo¢o∆
+#
+schmail.sheridanhospital.com.o∆
+
+sheridanhospital.com4o∆
+
+oab.baycollege.edu+’n∆
+
+th-mbg.waterfordmi.govI¢o∆
+#
+schspam.sheridanhospital.como∆
+
+sip.baycollege.edu!’n∆
+
+dev.nmu-media.orgA»n∆
+%
+sches.sch.sheridanhospital.com1o∆
+
+th-mbg.waterfordmi.govI¢o∆
+"
+autodiscover.baycollege.edu)’n∆
+
+mas.baycollege.edu‘n∆
+(
+!autodiscover.sheridanhospital.com.o∆
+
+kci-net.karmanos.orgå¯n∆
+&
+wideload.network.baycollege.edu!’n∆
+"
+autodiscover.baycollege.edu+’n∆
+
+karmanos.orgä¯n∆
+(
+!autodiscover.sheridanhospital.como∆
+
+mas.baycollege.edu‘n∆
+
+southfieldlibrary.org¢o∆
+%
+goldbug.network.baycollege.edu!’n∆
+
+mybay.baycollege.edu|‘n∆
+
+gateway.holyfam.org>o∆
+
+eas.baycollege.edu(’n∆
+%
+rollbar.network.baycollege.edu!’n∆
+#
+schspam.sheridanhospital.com.o∆
+
+outlook.baycollege.edu'’n∆
+
+housing.nmu.eduÀ»n∆
+(
+!autodiscover.sheridanhospital.com1o∆
+
+oos.baycollege.edu;’n∆
+
+	remc1.net¡◊n∆
+
+webconf1.baycollege.edu‘n∆
+%
+sches.sch.sheridanhospital.com.o∆
+
+sheridanhospital.com1o∆
+
+th-mbg.waterfordmi.govI¢o∆
+
+sheridanhospital.como∆
+
+
+macomb.eduQ8o∆
+%
+sches.sch.sheridanhospital.com2o∆
+!
+autodiscover.is.wccnet.org#∞o∆
+(
+!autodiscover.sheridanhospital.como∆
+
+northgate.lssu.edu›n∆
+
+eas.baycollege.edu)’n∆
+
+aquinas.edum˘n∆
+
+outlook.baycollege.edu+’n∆
+"
+th-micollab.waterfordmi.govI¢o∆
+"
+th-micollab.waterfordmi.govI¢o∆
+
+th-mbg.waterfordmi.govI¢o∆
+
+apps.waterfordmi.gov £o∆
+%
+sches.sch.sheridanhospital.como∆
+#
+schspam.sheridanhospital.como∆
+#
+schspam.sheridanhospital.como∆
+
+prtg2.lssu.eduåÿn∆
+!
+www.ydlpay.ypsilibrary.org®ßo∆
+)
+"www.vpn.dickinsoncountysheriff.net¢◊n∆
+ 
+ruiru1-dev.dev.wccnet.org,∞o∆
+
+mail.baycollege.edu+’n∆
+#
+schspam.sheridanhospital.com2o∆
+#
+schmail.sheridanhospital.como∆
+
+northgate.lssu.eduŸn∆
+
+northgate.lssu.eduﬂn∆
+"
+autodiscover.baycollege.edu(’n∆
+
+catalog.cantonpl.orgC§o∆
+ 
+inform.mackinacbridge.orgΩo∆
+
+iphubweb.umcu.orgÁºo∆
+
+karmanos.orgî¯n∆
+"
+th-micollab.waterfordmi.govI¢o∆
+#
+schmail.sheridanhospital.com4o∆
+(
+!autodiscover.sheridanhospital.como∆
+(
+!autodiscover.sheridanhospital.com4o∆
+
+rhpl.orgw¢o∆
+
+client.is.wccnet.org$∞o∆
+
+kci-net.karmanos.orgî¯n∆
+
+royaloakrec.com¶o∆
+
+clconnect-prod.lssu.eduàÿn∆
+
+pac.iamtgc.netÏo∆
+)
+"cpass-ilab-c1.ilab.umnet.umich.eduq‚o∆
+ 
+catalog.salinelibrary.org
+≠o∆
+%
+sches.sch.sheridanhospital.com4o∆
+
+sheridanhospital.como∆
+#
+schspam.sheridanhospital.como∆
+#
+schmail.sheridanhospital.como∆
+
+
+wccnet.eduº∞o∆
+
+plymouthlibrary.orgí¶o∆
+ 
+ruiru1-dev.dev.wccnet.org,∞o∆
+&
+securemail.sheridanhospital.com4o∆
+
+
+wccnet.eduL∞o∆
+
+aquinas.edu@ın∆
+
+ews.baycollege.edu+’n∆
+!
+autodiscover.is.wccnet.org$∞o∆
+
+webtime.wccnet.eduï∞o∆
+%
+sches.sch.sheridanhospital.como∆
+#
+schmail.sheridanhospital.com1o∆
+
+s3w.cantonpl.orgE§o∆
+
+mail.baycollege.edu(’n∆
+
+
+wccnet.eduí∞o∆
+
+th-mbg.waterfordmi.govI¢o∆
+
+gis.waterfordmi.govÃ£o∆
+#
+schmail.sheridanhospital.como∆
+%
+sches.sch.sheridanhospital.como∆
+
+ydlpay.ypsilibrary.org®ßo∆
+
+sheridanhospital.como∆
+
+
+wccnet.edu≤∞o∆
+
+hybrid.is.wccnet.org$∞o∆
+
+sheridanhospital.com.o∆
+
+baycollege.edu+’n∆
+
+oab.baycollege.edu'’n∆
+
+cidlibrary.org§o∆
+
+
+macomb.edu8o∆
+#
+schspam.sheridanhospital.com4o∆
+
+
+wccnet.eduW∞o∆
+
+
+wccnet.edu˝∞o∆
+
+www.apps.waterfordmi.gov £o∆
+
+autodiscover.wccnet.edu$∞o∆
+
+umcdev2.nmu.edu¨Àn∆
+
+
+wccnet.eduh∞o∆
+
+pac.iamtgc.netÏo∆
+
+ruiru.is.wccnet.org$∞o∆
+#
+schmail.sheridanhospital.com2o∆
+$
+www.catalog.salinelibrary.org
+≠o∆
+
+th-mbg.waterfordmi.govI¢o∆
+
+rhpl.orgs¢o∆
+
+client.is.wccnet.org#∞o∆
+
+ruiru.is.wccnet.org#∞o∆
+
+iphubweb.umcu.orgÁºo∆
+
+www.gis.waterfordmi.govÃ£o∆
+
+
+wccnet.edu‰∞o∆
+
+th-mbg.waterfordmi.govI¢o∆
+(
+!autodiscover.sheridanhospital.com2o∆
+&
+securemail.sheridanhospital.como∆
+
+autodiscover.wccnet.edu#∞o∆
+
+kellogg.eduoˇÎ∆
+
+catalog.cantonpl.orgC§o∆
+
+itbs.cantonpl.orgE§o∆
+
+ruiru.is.wccnet.org$∞o∆
+ 
+mobile.mackinacbridge.orgΩo∆
+(
+!autodiscover.sheridanhospital.como∆
+
+kellogg.edu#ˇÎ∆
+&
+securemail.sheridanhospital.com2o∆
+
+autodiscover.wccnet.edu$∞o∆
+
+www.iphubweb.umcu.orgÁºo∆
+
+kellogg.edu/ˇÎ∆
+
+kellogg.eduˇÎ∆
+
+mauth.cantonpl.orgE§o∆
+ 
+ruiru1-dev.dev.wccnet.org,∞o∆
+
+hybrid.is.wccnet.org#∞o∆
+&
+securemail.sheridanhospital.como∆
+
+
+wccnet.eduv∞o∆
+
+hybrid.is.wccnet.org$∞o∆
+
+www.pac.iamtgc.netÏo∆
+
+aadl.orgS&Ã
+
+aquinas.edue˘n∆
+
+www.iphubweb.umcu.orgÁºo∆
+
+
+wccnet.edu+∞o∆
+
+kellogg.edurˇÎ∆
+%
+sches.sch.sheridanhospital.como∆
+
+bssopprd.nmu.edu&Ã
+
+ems.wccnet.edu•∞o∆
+
+vlc.lib.mi.usÃo∆
+
+apache.mtri.org&Ã
+
+bssotest.nmu.edu%&Ã
+
+ne.netscout.comF&Ã
+
+
+wccnet.edu_∞o∆
+%
+sches.sch.sheridanhospital.como∆
+
+managedbyubx.comøo∆
+
+kellogg.eduÇˇÎ∆
+!
+autodiscover.is.wccnet.org$∞o∆
+
+kellogg.eduDˇÎ∆
+
+opg.mtri.org&Ã
+
+kellogg.edu|ˇÎ∆
+
+gravy.wccnet.edu∏∞o∆
+
+
+wccnet.edu·∞o∆
+
+kellogg.edu{ˇÎ∆
+#
+schmail.sheridanhospital.como∆
+
+media.aadl.orgb&Ã
+
+evergreen.aadl.org&Ã
+
+art.nmu.edu6&Ã
+
+pez.wccnet.edu¯∞o∆
+
+aadl.org&Ã
+
+client.is.wccnet.org$∞o∆
+
+www.pac.iamtgc.netÏo∆
+
+	diisd.org0&Ã
+
+webserver.mtri.org&Ã
+
+files.aadl.orgb&Ã
+
+evergreen.aadl.org&Ã
+
+ftp.mtri.org&Ã
+
+kellogg.eduˇÎ∆
+
+	diisd.org0&Ã
+
+hete.arbor.netX&Ã
+
+aadl.orgS&Ã
+
+kellogg.eduˇÎ∆
+
+fhirconnect.altarum.orgºjÃ
+
+kellogg.eduUˇÎ∆
+
+www.royaloakrec.com¶o∆
+
+	diisd.org+0&Ã
+
+kellogg.edu\ˇÎ∆
+
+kellogg.edu(ˇÎ∆
+
+mipscast.org%jÃ
+
+wiki.aadl.org&Ã
+
+bssoprod.nmu.edu
+&Ã
+
+bssoprod.nmu.edu
+&Ã
+
+kellogg.edujˇÎ∆
+
+	remc1.net0&Ã
+
+	diisd.orgG0&Ã
+
+mail.boynecity.comd*Hœ
+"
+www.gis.cityofwakefield.orgt*Hœ
+
+mail.lapeercmh.orgFHœ
+
+kellogg.eduIˇÎ∆
+
+mail.rtdl.orgÍ•o∆
+
+
+wccnet.eduC∞o∆
+
+wsu-elk.osris.org	√'Ã
+
+index.casscountymi.org1Hœ
+
+mipscast.com%jÃ
+
+bssopprd.nmu.edu&Ã
+
+www.mipscast.com%jÃ
+
+	diisd.org0&Ã
+
+utmobile.nmu.edu˛&Ã
+
+www.mail.miworks.orgs(&Ã
+
+nmu3cx.nmu.edu¥Ã&Ã
+
+	diisd.org0&Ã
+
+washtenawliteracy.orgd&Ã
+
+bssotest.nmu.edu%&Ã
+!
+www.index.casscountymi.org1Hœ
+
+kellogg.eduˇÎ∆
+
+vpn.arenaccountymi.gov"(&Ã
+
+bssotest.nmu.edu%&Ã
+!
+qualitymonitor.altarum.org%jÃ
+
+bsso.nmu.edu
+&Ã
+
+bsso.nmu.edu
+&Ã
+!
+AutoDiscover.boynecity.comd*Hœ
+
+	remc1.net0&Ã
+
+www.mipscast.org%jÃ
+
+bssoprod.nmu.edu
+&Ã
+
+gis.cityofwakefield.orgt*Hœ
+
+mail.lapeercmh.orgFHœ
+
+mail.miworks.orgs(&Ã
+
+cooper.nmu.edu¥Ã&Ã
+
+mail.lapeercmh.orgFHœ
+
+cooper.nmu.edu¥Ã&Ã
+
+bsso.nmu.edu
+&Ã
+
+vpn.norcocmh.orgIœ
+!
+AutoDiscover.boynecity.comd*Hœ
+
+vpn.norcocmh.orgIœ
+
+lapeercounty.orgFHœ
+
+www.hete.arbor.netX&Ã
+
+	diisd.org#0&Ã
+
+kellogg.eduGˇÎ∆
+!
+www.mi-connect.altarum.org9Hœ
+
+mail.lapeercmh.orgFHœ
+
+lapeercounty.orgFHœ
+
+wsu-grafana.osris.org√'Ã
+
+www.vpn.norcocmh.orgIœ
+
+vpn.arenaccountymi.gov"(&Ã
+
+boynecity.comd*Hœ
+
+vpn.norcocmh.orgIœ
+
+norcocmh.orgIœ
+
+boynecity.comd*Hœ
+
+mi-connect.altarum.org9Hœ
+
+www.vpn.norcocmh.orgIœ
+
+apsssuite.comK1Hœ
+
+mail.lapeercmh.orgFHœ
+
+www.vpn.norcocmh.orgIœ
+
+www.lapeercounty.orgFHœ
+
+
+my.ltu.eduÒ@Iœ
+
+vpn.norcocmh.orgIœ
+
+www.vpn.norcocmh.orgIœ
+
+mail.boynecity.comd*Hœ
+
+lapeercounty.orgFHœ
+
+vpn.norcocmh.orgIœ
+
+www.vpn.norcocmh.orgIœ
+
+www.support.stjcmi.org
+!Jœ
+
+www.vpn.norcocmh.orgIœ
+
+powerschool.mcbain.orgGJœ
+
+vpn.norcocmh.orgIœ
+
+www.vpn.norcocmh.orgIœ
+
+www.mypassword.ltu.eduj@Iœ
+
+remote.cityofhart.org.5Jœ
+
+vpn.norcocmh.orgIœ
+
+www.vpn.norcocmh.orgIœ
+
+mypassword.ltu.eduj@Iœ
+!
+www.powerschool.mcbain.orgGJœ
+
+vpn.norcocmh.orgIœ
+
+vpn.norcocmh.orgIœ
+
+powerschool.mcbain.orgGJœ
+
+support.stjcmi.org
+!Jœ
+
+www.vpn.norcocmh.orgIœ
+!
+www.powerschool.mcbain.orgGJœ
+ 
+www.remote.cityofhart.org.5Jœ
+
+
+wccnet.eduÄIœ
+
+powerschool.mcbain.orgGJœ
+
+www.vpn.norcocmh.orgIœ
+1
+*wmcmh-heart-wired-vrhbgbgqwj.dynamic-m.com¬5Jœ
+
+vpn.norcocmh.orgIœ
+
+smtp.alconahc.orgxMJœ
+
+mccezproxy.palnet.info:!Jœ
+
+imap.alconahc.orgxMJœ
+
+remote.ahcis.netdMJœ
+"
+remote.charlevoixcounty.orgX=Jœ
+
+www.my.ltu.eduÒ@Iœ
+
+mail.alconahc.orgxMJœ
+"
+micollab.hillmanschools.commRJœ
+
+bakerezproxy.palnet.info8!Jœ
+
+gaylord.k12.mi.us%ßJœ
+"
+micollab.hillmanschools.commRJœ
+
+mbg.hillmanschools.commRJœ
+
+mbg.hillmanschools.commRJœ
+
+mbg.hillmanschools.commRJœ
+!
+selfservice.ccsdetroit.edu,√Jœ
+
+gladwincounty-mi.govŸOJœ
+ 
+autodiscover.alconahc.orgxMJœ
+ 
+autodiscover.alconahc.orgxMJœ
+
+mail.cctransit.orgRßJœ
+3
+,ford-vcs-e.web.collegeforcreativestudies.edu(√Jœ
+
+connect.ahcis.netfMJœ
+
+www.ww3.madonna.edu<®Jœ
+!
+foodservice.wbrc.k12.mi.usÌOJœ
+,
+%pwreset.collegeforcreativestudies.edu√Jœ
+
+www.vpn.norcocmh.orgIœ
+5
+.wmcmh-ludington-wired-jrhwgvmmwj.dynamic-m.comB5Jœ
+
+smtp.alconahc.orgxMJœ
+
+msu-omd.osris.org	ŸIœ
+
+imap.alconahc.orgxMJœ
+!
+selfservice.ccsdetroit.edu,√Jœ
+-
+&meredith.collegeforcreativestudies.edu˛√Jœ
+
+voice.nemcworks.org§cKœ
+
+msu-grafana.osris.orgŸIœ
+"
+micollab.hillmanschools.commRJœ
+
+voice.nemcworks.org¢cKœ
+
+vpn.norcocmh.orgIœ
+ 
+www.portaldev.madonna.edue®Jœ
+
+aov.kabu.netµOJœ
+
+voice.nemcworks.org¢cKœ
+
+mail.oceanamcf.orgrJœ
+!
+autodiscover.oceanamcf.orgrJœ
+!
+autodiscover.cctransit.orgRßJœ
+
+voice.nemcworks.org§cKœ
+
+www.mail.oceanamcf.orgrJœ
+
+mail.alconahc.orgxMJœ
+
+smtp.alconahc.orgxMJœ
+
+ebill.pieg.com√OJœ
+!
+www.powerschool.mcbain.orgGJœ
+
+smtp.alconahc.orgxMJœ
++
+$campus.collegeforcreativestudies.edu!√Jœ
+3
+,ford-vcs-e.web.collegeforcreativestudies.edu(√Jœ
+
+access.ccsdetroit.edu&√Jœ
+
+imap.alconahc.orgxMJœ
+
+ww3.madonna.edu<®Jœ
+
+mbg.hillmanschools.commRJœ
+
+mail.alconahc.orgxMJœ
+
+mugate.madonna.edu®Jœ
+ 
+autodiscover.alconahc.orgxMJœ
+
+voice.nemcworks.org§cKœ
+
+www.mail.cctransit.orgRßJœ
+
+www.sts.montcounty.org¬MJœ
+
+acvpn.mfbhosp.orgÇ∆Jœ
+$
+collegeforcreativestudies.edu(√Jœ
+!
+selfservice.ccsdetroit.edu,√Jœ
+
+oceanamcf.orgrJœ
+
+sfdc-vsec01.merit.eduXtKœ
+.
+'expy-ford.collegeforcreativestudies.edu(√Jœ
+)
+"luna.collegeforcreativestudies.edu»√Jœ
+
+sts.montcounty.org¬MJœ
+0
+)selfservice.collegeforcreativestudies.edu,√Jœ
+
+alpenaschools.comáOJœ
+
+sfdc-view02.merit.eduXtKœ
+
+deepfield.net[•Kœ
+
+sp.training.incommon.org'§Kœ
+
+kettering.edurJœ
+
+www.view.maryfreebed.com¨∆Jœ
+
+mbg.hillmanschools.commRJœ
+
+mail.alconahc.orgxMJœ
+
+vpn.crystalfalls.org)Kœ
+(
+!web.collegeforcreativestudies.edu(√Jœ
+
+mfb-hrz-cb02.mfbhosp.org¨∆Jœ
+
+view.maryfreebed.com¨∆Jœ
+3
+,ford-vcs-e.web.collegeforcreativestudies.edu(√Jœ
+
+vpn.lvdhealthcenter.com\7Kœ
+
+omeka.ccsdetroit.edu7√Jœ
+
+webmail.cctransit.orgRßJœ
+
+portaldev.madonna.edue®Jœ
+
+attendanceondemand.com˚Kœ
+
+voice.nemcworks.org¢cKœ
+
+www.view.maryfreebed.com¨∆Jœ
+
+www.mugate.madonna.edu®Jœ
+.
+'expy-ford.collegeforcreativestudies.edu(√Jœ
+
+www.gis.escanaba.org%(Kœ
+(
+!idp.collegeforcreativestudies.edu&√Jœ
+
+sfdc-view01.merit.eduXtKœ
+
+mfb-hrz-cb03.mfbhosp.org¨∆Jœ
+
+view.mfbhosp.org¨∆Jœ
+
+crdl.orgeKœ
+
+simbridge.baycollege.eduñRKœ
+ 
+www.campus.ccsdetroit.edu!√Jœ
+
+campus.ccsdetroit.edu!√Jœ
+
+crdl.orgeKœ
+
+hackleylibrary.mi.3cx.usºrJœ
+
+ds.training.incommon.org'§Kœ
+
+gaylord.k12.mi.us%ßJœ
+
+icsenforcer.com®qKœ
+(
+!sma.collegeforcreativestudies.edu6√Jœ
+)
+"auth.collegeforcreativestudies.edu8√Jœ
+
+mail.merit.eduΩtKœ
+
+mbg.hillmanschools.commRJœ
+
+	remc1.net5Kœ
+(
+!web.collegeforcreativestudies.edu(√Jœ
+
+crdl.orgeKœ
+
+luna.ccsdetroit.edu»√Jœ
+
+voice.nemcworks.org¢cKœ
+(
+!merit-pdreceiver-prod01.merit.eduftKœ
+0
+)selfservice.collegeforcreativestudies.edu,√Jœ
+
+hillsdale.edu(ÍKœ
+"
+merit-hscc-prod01.merit.eduVtKœ
+4
+-wmcc-kalamazoo-wired-wprnkcgvzm.dynamic-m.comSqKœ
+*
+#omeka.collegeforcreativestudies.edu7√Jœ
+
+www.helpdesk.tln.orgÙ¢Kœ
+$
+collegeforcreativestudies.edu(√Jœ
+
+helpdesk.tln.orgÙ¢Kœ
+
+pdreceiver.merit.eduftKœ
+
+ra.nettKœ
+
+mfb-hrz-cb02.mfbhosp.org¨∆Jœ
+
+	remc1.net?Kœ
+
+catalog.tln.lib.mi.us°Kœ
+
+hillsdale.eduNÍKœ
+"
+www.vpn.lvdhealthcenter.com\7Kœ
+
+sfdc-view02.merit.eduYtKœ
+
+idp.merit.edu uKœ
+
+www.acvpn.mfbhosp.orgÇ∆Jœ
+
+sfdc-view02.merit.eduYtKœ
+
+merit-idp01.merit.edu uKœ
+
+	merit.edu–tKœ
+
+auth.ccsdetroit.edu8√Jœ
+ 
+autodiscover.alconahc.orgxMJœ
+
+hillsdale.eduWÍKœ
+
+hillsdale.edu=ÍKœ
+
+hillsdale.eduRÍKœ
+
+	merit.edu9uKœ
+ 
+idp.training.incommon.org'§Kœ
+
+www.vpn.crystalfalls.org)Kœ
+
+eupschools.org”Kœ
+
+vpn.baycollege.edu:RKœ
+/
+(www.campus.collegeforcreativestudies.edu!√Jœ
+
+hillsdale.eduÍKœ
+.
+'expy-ford.collegeforcreativestudies.edu(√Jœ
+(
+!web.collegeforcreativestudies.edu(√Jœ
+
+	remc1.net∂¬Kœ
+
+stash.merit.edu¡tKœ
+
+attendanceondemand.com˙Kœ
+
+fg1a.ioscocounty.org"∫Kœ
+
+hillsdale.edu4ÍKœ
+
+hillsdale.edu`ÍKœ
+
+alpenaschools.comjOJœ
+
+hillsdale.edu0ÍKœ
+
+hillsdale.eduOÍKœ
+
+hillsdale.edu=ÍKœ
+
+hillsdale.eduRÍKœ
+%
+boardbook.nmu.edu2 H® íòí D
+ 
+imap.nmu.edu2 H® íòí D
+!
+mail1.nmu.edu2 H® íòí D
+#
+myuser2.nmu.edu2 H® íòí a
+
+nic.nmu.edu2 H® íòí D
+#
+srvsweb.nmu.edu2 H® íòí D
+!
+myweb.nmu.edu2 H® íòí D
+#
+webmail.nmu.edu2 H® íòí I
+#
+arcmail.nmu.edu2 H® íòí D
+$
+webpages.nmu.edu2 H® íòí D
+"
+myusr1.nmu.edu2 H® íòí a
+"
+myuser.nmu.edu2 H® íòí a
+"
+myusr2.nmu.edu2 H® íòí a
+!
+rocky.nmu.edu2 H® íòí I
+#
+regtest.nmu.edu2 H® íòí D
+%
+roundcube.nmu.edu2 H® íòí I
+
+pop.nmu.edu2 H® íòí D
+%
+wolverine.nmu.edu2 H® íòíB
+%
+mailshare.nmu.edu2 H® !ôòô 
+$
+listserv.nmu.edu2 H® !ôòô 
+"
+lstsrv.nmu.edu2 H® !ôòô 
+"
+beaker.nmu.edu2 H® !ôòô 
+#
+mlshare.nmu.edu2 H® !ôòô 
+!
+mlist.nmu.edu2 H® !ôòô 
+"
+nmuebs.nmu.edu2 H® !ôòô 
+"
+ittech.nmu.edu2 H® !ôòô 
+"
+muninn.nmu.edu2 H® !ôòô 
+&
+enterprise.nmu.edu2 H® !ôòô 1
+#
+imginfo.nmu.edu2 H® !ôòô 
+"
+icinga.nmu.edu2 H® !ôòô 
+"
+pigpen.nmu.edu2 H® !ôòô 
+%
+kenny.acs.nmu.edu2 H® !ôòô 
+!
+kenny.nmu.edu2 H® !ôòô 
+&
+enterprise.nmu.edu2 H® !ôòô 
+!
+munin.nmu.edu2 H® !ôòô 
+"
+moonin.nmu.edu2 H® !ôòô 
+#
+imginfo.nmu.edu2 H® !ôòô 1
+"
+ittech.nmu.edu2 H® !ôòô 1
+"
+nmuebs.nmu.edu2 H® !ôòô 1
+"
+pigpen.nmu.edu2 H® !ôòô 1
+%
+catalysts.nmu.edu2 H® !ôòô A
+%
+blogs.acs.nmu.edu2 H® !ôòô A
+#
+lovejoy.nmu.edu2 H® !ôòô A
+#
+www.acs.nmu.edu2 H® !ôòô A
+$
+wiki.acs.nmu.edu2 H® !ôòô A
+
+
+it.nmu.edu2 H® !ôòô A
+"
+hdwiki.nmu.edu2 H® !ôòô A
+ 
+apps.nmu.edu2 H® !ôòô q
+$
+notebook.nmu.edu2 H® !ôòô Y
+$
+wildcast.nmu.edu2 H® !ôòô i
+"
+educat.nmu.edu2 H® "ò 
+$
+devapply.nmu.edu2 H® !ôòô r
+!
+apply.nmu.edu2 H® !ôòô p
+"
+ike2jj.nmu.edu2 H® "ò !
+$
+internal.nmu.edu2 H® !ôòô q
+ 
+ike2.nmu.edu2 H® "ò !
+*
+devorientation.nmu.edu2 H® !ôòô r
+"
+ike2km.nmu.edu2 H® "ò !
+#
+charlie.nmu.edu2 H® 2 ò  
+(
+nmudrivetest.nmu.edu2 H® 2 r  
+
+
+d7.nmu.edu2 H® 2 ò  
+
+www.nmu.edu2 H® 2 ò  
+%
+alexander.nmu.edu2 H® 2 r  
+%
+dev.nmu-media.com2 H® 2 ò  
+&
+maap.nmu-media.com2 H® 2 ò  
+ 
+webb.nmu.edu2 H® 2 ò  
+&
+photo.up200nmu.com2 H® 2 ò  
+!
+nmu-media.com2 H® 2 ò  
+ 
+up200nmu.com2 H® 2 ò  
+'
+photo.nmu-media.com2 H® 2 ò  
+%
+dev.nmu-media.org2 H® 2 ò  e
+
+maap.org2 H® 2 ò  
+
+idp.nmu.edu2 H® 2 ò  I
+#
+marbles.nmu.edu2 H® 2 ò  
+
+dev.nmu.edu2 H® 2 ò  e
+&
+foundation.nmu.edu2 H® 2 ò  e
+,
+foundation.nmu-media.org2 H® 2 ò  e
+$
+franklin.nmu.edu2 H® 2 ò  e
+&
+news.nmu-media.org2 H® 2 ò  e
+
+nmu.edu2 H® 2 ò  e
+&
+alexandria.nmu.edu2 H® 2 ò  
+!
+nmu-media.org2 H® 2 ò  e
+ 
+news.nmu.edu2 H® 2 ò  e
+"
+mytest.nmu.edu2 H® 2 ò 
+$
+nmudrive.nmu.edu2 H® 2 ò  
+#
+umcdev1.nmu.edu2 H® 2òq
+'
+umcdev1-dev.nmu.edu2 H® 2òq
+!
+mynmu.nmu.edu2 H® 2 ò %
+
+leo.nmu.edu2 H® 2 ò 
+"
+cmssso.nmu.edu2 H® 2 ò D
+#
+umcdev2.nmu.edu2 H® 2òr
+.
+umcdev1-foundation.nmu.edu2 H® 2òq
+(
+umcdev1-news.nmu.edu2 H® 2òq
+
+nmu.college2 H® 2òq
+#
+umcdev3.nmu.edu2 H® 2òs
+#
+umcdev4.nmu.edu2 H® 2òó
+$
+capsrv.aglt2.org2 H®h˜ í A0E
+&
+psumvm02.aglt2.org2 H®h˜ í A1 B
+%
+maddash.aglt2.org2 H®h˜ í A1
+&
+psumvm01.aglt2.org2 H®h˜ í A1 E
+2
+meshconfig.opensciencegrid.org2 H®h˜Äí A6
+"
+psdb.aglt2.org2 H®h˜ í A1G
+-
+psmad.opensciencegrid.org2 H®h˜ í A1
+&
+psconfig.aglt2.org2 H®h˜Äí A6
+0
+psconfig.opensciencegrid.org2 H®h˜Äí A6
+)
+aaof-gw-fin.merit.edu2 H®hÄ        
+,
+aaof-gw-netops.merit.edu2 H®hÄ        #
+)
+aaof-gw-msc.merit.edu2 H®hÄ        $
+$
+domreg.merit.edu2 H®hÄ h    
++
+aaof-gw-staff.merit.edu2 H®hÄ        
+&
+alexandria.nmu.edu2 H® 2 ò  
++
+aaof-gw-swdev.merit.edu2 H®hÄ        
+)
+aaof-gw-sec.merit.edu2 H®hÄ        
+
+
+domreg.org2 H®hÄ h    
+!
+cus.wayne.edu2&ó B      ´Õ
+1
+merit-domreg-prod01.merit.edu2 H®hÄ h    
+
+www.nmu.edu2 H® 2 ò  
+!
+eng.wayne.edu2&ó B      ´Õ
+!
+mail1.nmu.edu2 H® íòí D
+$
+franklin.nmu.edu2 H® 2 ò  e
+ 
+ike2.nmu.edu2 H® "ò !
+"
+educat.nmu.edu2 H® "ò 
+$
+franklin.nmu.edu2 H® 2 ò  e
+
+idp.nmu.edu2 H® 2 ò  I
+%
+kenny.acs.nmu.edu2 H® !ôòô 
+"
+beaker.nmu.edu2 H® !ôòô 
+
+leo.nmu.edu2 H® 2 ò 
+ 
+ike2.nmu.edu2 H® "ò !
+!
+mail1.nmu.edu2 H® íòí D
+$
+capsrv.aglt2.org2 H®h˜ í A0E
+
+www.nmu.edu2 H® 2 ò  
+#
+marbles.nmu.edu2 H® 2 ò  
+!
+mail1.nmu.edu2 H® íòí D
+"
+pigpen.nmu.edu2 H® !ôòô 
+*
+merit-jira02.merit.edu2 H®hÄ h    ë
+ 
+ike2.nmu.edu2 H® "ò !
+"
+pigpen.nmu.edu2 H® !ôòô 
+/
+michiganbroadbandsummit.org2 H®hÄ h     
+$
+franklin.nmu.edu2 H® 2 ò  e
+)
+merit-idp01.merit.edu2 H®hÄ h       
+%
+kenny.acs.nmu.edu2 H® !ôòô 
+
+nmu.edu2 H® 2 ò  e
+*
+merit-jira02.merit.edu2 H®hÄ h    ë
+
+irr.net2 H®hÄ h      
+)
+merit-idp01.merit.edu2 H®hÄ h       
+5
+!merit-pdreceiver-test01.merit.edu2 H®hÄ h    
+/
+merit-hscc-prod01.merit.edu2 H®hÄ h     Ü
+!
+mail1.nmu.edu2 H® íòí D
+"
+psdb.aglt2.org2 H®h˜ í A1G
+(
+michiganmoonshot.org2 H®hÄ h     
+)
+origin1.internet2.edu2 h&          "
+1
+merit-domreg-prod01.merit.edu2 H®hÄ h    
+)
+origin1.internet2.edu2 h&          "
+/
+michiganbroadbandsummit.net2 H®hÄ h     
+%
+kenny.acs.nmu.edu2 H® !ôòô 
+9
+%nso-sandbox-dev.macc.ns.internet2.edu2 h&·       Å
+!
+mynmu.nmu.edu2 H® 2 ò %
+&
+psconfig.aglt2.org2 H®h˜Äí A6
+
+leo.nmu.edu2 H® 2 ò 
+&
+alexandria.nmu.edu2 H® 2 ò  
+/
+michiganbroadbandsummit.com2 H®hÄ h     
+%
+protect.wayne.edu2&ó /Ú       
+!
+mail1.nmu.edu2 H® íòí D
+$
+franklin.nmu.edu2 H® 2 ò  e
+/
+merit-bitbucket02.merit.edu2 H®hÄ h    ì
+5
+!merit-pdreceiver-prod01.merit.edu2 H®hÄ h    
+&
+psumvm01.aglt2.org2 H®h˜ í A1 E
+(
+michiganmoonshot.net2 H®hÄ h     
+&
+psconfig.aglt2.org2 H®h˜Äí A6
+&
+psconfig.aglt2.org2 H®h˜Äí A6
+"
+pigpen.nmu.edu2 H® !ôòô 
+&
+psumvm02.aglt2.org2 H®h˜ í A1 B
+
+	umich.edu2&         
+%
+maddash.aglt2.org2 H®h˜ í A1
+!
+mail1.nmu.edu2 H® íòí D
+%
+maddash.aglt2.org2 H®h˜ í A1
+!
+rocky.nmu.edu2 H® íòí I
+%
+kenny.acs.nmu.edu2 H® !ôòô 
+!
+mail1.nmu.edu2 H® íòí D
+%
+kenny.acs.nmu.edu2 H® !ôòô 
+!
+vpn.merit.edu2 H®hÄ        
+/
+merit-bitbucket02.merit.edu2 H®hÄ h    ì
+(
+michiganmoonshot.com2 H®hÄ h     
+!
+rocky.nmu.edu2 H® íòí I
+#
+umcdev1.nmu.edu2 H® 2òq
+!
+mail1.nmu.edu2 H® íòí D
+#
+umcdev4.nmu.edu2 H® 2òó
+#
+umcdev2.nmu.edu2 H® 2òr
+!
+rocky.nmu.edu2 H® íòí I
+#
+umcdev1.nmu.edu2 H® 2òq
+1
+merit-domreg-prod01.merit.edu2 H®hÄ h    
+5
+!merit-pdreceiver-prod01.merit.edu2 H®hÄ h    
+
+	wayne.edu2&ó B      ´Õ
+#
+umcdev1.nmu.edu2 H® 2òq
+%
+wolverine.nmu.edu2 H® íòíB
+#
+umcdev1.nmu.edu2 H® 2òq
+=
+)nso-sandbox-testing.macc.ns.internet2.edu2 h&·       Ç
+#
+umcdev3.nmu.edu2 H® 2òs
+
+www.nmu.edu2 H® 2 ò  
+
+
+domreg.org2 H®hÄ h    
+!
+mail1.nmu.edu2 H® íòí D
+1
+merit-domreg-prod01.merit.edu2 H®hÄ h    
+
+
+domreg.org2 H®hÄ h    
+,
+www.michiganmoonshot.com2 H®hÄ h     
+!
+www.umich.edu2&         
+,
+www.michiganmoonshot.net2 H®hÄ h     
+,
+www.michiganmoonshot.org2 H®hÄ h     
+
+www.nmu.edu2 H® 2 ò  
+*
+washtenawbroadband.org2 H®hÄ h     
+.
+www.washtenawbroadband.org2 H®hÄ h     
+
+tlstest.vpnalyzer.com}{‘ç
+
+meow.vpnalyzer.com2{‘ç
+
+tlstest.vpnalyzer.comÖ{‘ç
+
+tlstest.vpnalyzer.comÄ{‘ç
+
+tlstest.vpnalyzer.comÑ{‘ç
+
+tlstest.vpnalyzer.comÜ{‘ç
+
+bark.vpnalyzer.com0{‘ç
+
+tlstest.vpnalyzer.com}{‘ç
+
+tlstest.vpnalyzer.comÅ{‘ç
+
+tlstest.vpnalyzer.com~{‘ç
+
+loc.vpnalyzer.net◊{‘ç
+
+loc.vpnalyzer.net⁄{‘ç
+
+loc.vpnalyzer.netŸ{‘ç
+
+loc.vpnalyzer.net‹{‘ç
+
+loc.vpnalyzer.net€{‘ç
+
+loc.vpnalyzer.netÿ{‘ç
+
+psr.vpnalyzer.com·{‘ç
+
+loc.vpnalyzer.net›{‘ç
+
+loc.vpnalyzer.netﬁ{‘ç
+
+loc.vpnalyzer.net‡{‘ç
+
+psr.vpnalyzer.com‚{‘ç
+
+psr.vpnalyzer.com„{‘ç
+
+psr.vpnalyzer.com‰{‘ç
+
+psr.vpnalyzer.comÂ{‘ç
+
+psr.vpnalyzer.comÊ{‘ç
+
+psr.vpnalyzer.comÍ{‘ç
+
+psr.vpnalyzer.comË{‘ç
+
+psr.vpnalyzer.comÈ{‘çë	$
+ ”
+ãñ¥a8ºõf)"F¬“™25Í1*)[&˜CZ"à
+7
+141.219.0.0/1635.8.0.0/162001:48a8:5fe0::1/64 
+à
+192.122.184.0/24192.203.195.0/24192.88.242.0/24192.41.229.0/24206.201.157.0/24192.35.168.0/232001:48a8:5fe0:0001::1/64
+#128.138.0.0/162620:18f::/32
+,35.8.0.0/242001:48a8:5fe0:0002::1/64
+E
+192.122.190.0/242001:48a8:687f:2::/642001:48a8:7fff:b::2/64
+(35.6.0.0/162001:48a8:687f:2::/64 *$
+ °Àóæi|^’Æ˝xˇ§€~h$`5‰
+âï¡XÄqwZ2öhttps://1.1.1.1/dns-queryr.refraction.network" °Àóæi|^’Æ˝xˇ§€~h$`5‰
+âï¡XÄqw*$3*Firefox_65,1*Firefox_63,1*iOS_12_12stun.voip.blackberry.com:3478

--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -463,8 +463,6 @@ func updateDNSReg(cc *pb.ClientConf, new *pb.DnsRegConf) {
 
 func appendToml(clientConf *pb.ClientConf, tomlPath string) {
 
-	// fileName := "phantom_subnets.toml"
-	// fileName = subnet_file
 	file, err := os.OpenFile(tomlPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Fatalf("Failed to open file: %s", err)

--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -476,7 +476,7 @@ func appendToml(clientConf *pb.ClientConf, tomlPath string) {
 	phantoms := clientConf.GetPhantomSubnetsList()
 	if phantoms != nil {
 		for _, block := range phantoms.GetWeightedSubnets() {
-			fmt.Fprintf(file, "\t\t[[Networks.%d.WeightedSubnets]]\n", clientConf.GetGeneration())
+			fmt.Fprintf(file, "\t[[Networks.%d.WeightedSubnets]]\n", clientConf.GetGeneration())
 			fmt.Fprintf(file, "\t\t\tWeight = %d\n", block.GetWeight())
 			fmt.Fprintf(file, "\t\t\tRandomizeDstPort = %t\n", block.GetRandomizeDstPort())
 			fmt.Fprintf(file, "\t\t\tSubnets = [")

--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -471,15 +471,15 @@ func appendToml(clientConf *pb.ClientConf, tomlPath string) {
 	}
 	defer file.Close()
 
-	fmt.Fprintf(file, "\n\t[Networks.%d]\n", clientConf.GetGeneration())
+	fmt.Fprintf(file, "\n    [Networks.%d]\n", clientConf.GetGeneration())
 	fmt.Fprintf(file, "\tGeneration = %d\n", clientConf.GetGeneration())
 	phantoms := clientConf.GetPhantomSubnetsList()
 	if phantoms != nil {
 		for _, block := range phantoms.GetWeightedSubnets() {
 			fmt.Fprintf(file, "\t[[Networks.%d.WeightedSubnets]]\n", clientConf.GetGeneration())
-			fmt.Fprintf(file, "\t\t\tWeight = %d\n", block.GetWeight())
-			fmt.Fprintf(file, "\t\t\tRandomizeDstPort = %t\n", block.GetRandomizeDstPort())
-			fmt.Fprintf(file, "\t\t\tSubnets = [")
+			fmt.Fprintf(file, "            Weight = %d\n", block.GetWeight())
+			fmt.Fprintf(file, "            RandomizeDstPort = %t\n", block.GetRandomizeDstPort())
+			fmt.Fprintf(file, "            Subnets = [")
 			index := 0
 			for _, subnet := range block.GetSubnets() {
 				fmt.Fprintf(file, "\"%s\"", subnet)

--- a/tools/clientconf/clientconf.go
+++ b/tools/clientconf/clientconf.go
@@ -543,7 +543,7 @@ func main() {
 	)
 	var print_pairs = flag.Bool("print-pairs", false, "Print pairs of decoys ip,sni")
 
-	var appendTomlFile = flag.String("append-toml-path", "", "append clientconf to some file path")
+	var appendTomlFile = flag.String("append-toml-path", "", "Path of phantom_subnets.toml file to append the parsed (via -f) ClientConf subnets to. If path doesn't exist, a new file pointed to by the path will be created")
 	flag.Parse()
 
 	clientConf := &pb.ClientConf{}


### PR DESCRIPTION
Added a feature for appending clienfconf
Specify the path of phantom_subnets.toml file(via --append-toml-path) to append the parsed (via -f) ClientConf subnets to. 
If path doesn't exist, a new file pointed to by the path will be created