### PR TITLE
functionality for registering on behalf of a client

### DIFF
--- a/tapdance/conjure.go
+++ b/tapdance/conjure.go
@@ -141,6 +141,12 @@ type ConjureSession struct {
 
 	// performance tracking
 	stats *pb.SessionStats
+
+	//registerFor flag
+	RegisterOnBehalfOf bool
+
+	// registerFor value
+	RegisterFor *net.IP
 }
 
 // MakeConjureSessionSilent creates a conjure session without logging anything

--- a/tapdance/dialer.go
+++ b/tapdance/dialer.go
@@ -66,6 +66,9 @@ type Dialer struct {
 
 	// Whether we want to register and connect to a phantom, or register only
 	RegisterOnly bool
+
+	//register for a client, value being their original IP
+	RegisterFor string
 }
 
 // Dial connects to the address on the named network.
@@ -173,6 +176,16 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 		cjSession.UseProxyHeader = d.UseProxyHeader
 		cjSession.DisableRegistrarOverrides = d.DisableRegistrarOverrides
 		cjSession.RegDelay = d.RegDelay
+
+		if d.RegisterFor != "" {
+			cjSession.RegisterOnBehalfOf = true
+			parsedIP := net.ParseIP(d.RegisterFor)
+			if parsedIP == nil {
+				fmt.Println("Invalid IP address")
+				return nil, errors.New("Invalid IP address to register on behalf of")
+			}
+			cjSession.RegisterFor = &parsedIP
+		}
 
 		if d.V6Support {
 			cjSession.V6Support = &V6{include: both, support: true}


### PR DESCRIPTION
### Overview:
This PR adds functionality for the 'register-on-behalf-of' feature, which relies on the [auxiliary functionality](https://github.com/refraction-networking/conjure/pull/279) added in the conjure repo. This feature allows users to register on behalf of a client by specifying the client's IP using the `-register-for` flag.

### Changes:
- Added a new flag: `-register-for`, to support registering on behalf of a client.
- Modified the bdapi registration flow to align with changes in the conjure repo.

### Dependencies:
This PR depends on the changes made in [conjure repo PR #279](https://github.com/refraction-networking/conjure/pull/279). Please ensure that the conjure PR is merged first before reviewing this one.

### Testing:
- Tested using an AWS instance, registering on behalf of the instance using its IPv4 address with the `-register-for` flag.
- Verified that the new functionality integrates well with the existing codebase.




