### PR TITLE
Update Tor conjure dependency to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sergeyfrolov/bsbuffer v0.0.0-20180903213811-94e85abb8507
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
-	gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/conjure v0.0.0-20250401212049-c593391b702a
+	gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/conjure v0.0.0-20250528190020-77bf2fef6e15
 	golang.org/x/crypto v0.33.0
 	golang.org/x/net v0.35.0
 	google.golang.org/protobuf v1.36.5
@@ -57,5 +57,3 @@ require (
 replace github.com/pion/dtls/v2 => github.com/mingyech/dtls/v2 v2.0.0
 
 replace github.com/pion/transport/v2 => github.com/mingyech/transport/v2 v2.0.0
-
-replace gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/conjure => gitlab.torproject.org/onyinyang/conjure v0.0.0-20250403173837-5b5bb3154613

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3i
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 gitlab.torproject.org/onyinyang/conjure v0.0.0-20250403173837-5b5bb3154613 h1:6+hjg5Ox1dFOCnMyP6LghyREWbX2MkRhzqTMvbfhMLk=
 gitlab.torproject.org/onyinyang/conjure v0.0.0-20250403173837-5b5bb3154613/go.mod h1:Ws2BKodaK7iy1D8xTSZ8bs8NKWfWa6JVOMUPpSqnMDc=
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/conjure v0.0.0-20250528190020-77bf2fef6e15 h1:LwDZaEctZW+A+OTZtUHcMCtiahQAjuhaczAjWwGAi+Q=
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/conjure v0.0.0-20250528190020-77bf2fef6e15/go.mod h1:tX3h9wSxsOUqKBP5abHT5tOA+r5dsK2gwishYASRvl8=
 gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib v1.6.0 h1:KD9m+mRBwtEdqe94Sv72uiedMWeRdIr4sXbrRyzRiIo=
 gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib v1.6.0/go.mod h1:70bhd4JKW/+1HLfm+TMrgHJsUHG4coelMWwiVEJ2gAg=
 gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/ptutil v0.0.0-20250130151315-efaf4e0ec0d3 h1:pwWCiqrB6b3SynILsv3M+76utmcgMiTZ2aqfccjWmxo=


### PR DESCRIPTION
This updates the dependency on Tor's conjure dependency to the latest @ main instead of my branch with a commit that doesn't seem to exist anymore.